### PR TITLE
Update Jacoco exclusion pattern for gradle classes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,14 +121,14 @@ try {
                 }finally {
                     jacoco(execPattern: 'build/jacoco/test.exec', buildOverBuild: true,
                         exclusionPattern: 'uk/gov/hmcts/dm/DmApp.java,'+
-                            'uk/gov/hmcts/dm/hateos/*,'+
-                            'uk/gov/hmcts/dm/exception/*,'+
-                            'uk/gov/hmcts/dm/domain/*,'+
-                            'uk/gov/hmcts/dm/commandobject/*,'+
-                            'uk/gov/hmcts/dm/hibernate/*,'+
-                            'uk/gov/hmcts/dm/config/**/*,'+
-                            'uk/gov/hmcts/dm/errorhandler/*,'+
-                            'uk/gov/hmcts/dm/repository/RepositoryFinder.java')
+                            '**/uk/gov/hmcts/dm/hateos/*,'+
+                            '**/uk/gov/hmcts/dm/exception/*,'+
+                            '**/uk/gov/hmcts/dm/domain/*,'+
+                            '**/uk/gov/hmcts/dm/commandobject/*,'+
+                            '**/uk/gov/hmcts/dm/hibernate/*,'+
+                            '**/uk/gov/hmcts/dm/config/**/*,'+
+                            '**/uk/gov/hmcts/dm/errorhandler/*,'+
+                            '**/uk/gov/hmcts/dm/repository/RepositoryFinder.java')
                     publishHTML([
                         allowMissing         : false,
                         alwaysLinkToLastBuild: false,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -120,7 +120,8 @@ try {
                     sh './gradlew jacocoTestReport --info'
                 }finally {
                     jacoco(execPattern: 'build/jacoco/test.exec', buildOverBuild: true,
-                        exclusionPattern: 'uk/gov/hmcts/dm/DmApp.java,'+
+                        exclusionPattern: '**/test/*' +
+                            '**/uk/gov/hmcts/dm/DmApp.java,'+
                             '**/uk/gov/hmcts/dm/hateos/*,'+
                             '**/uk/gov/hmcts/dm/exception/*,'+
                             '**/uk/gov/hmcts/dm/domain/*,'+


### PR DESCRIPTION
Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Exclusions don't seem to be working properly in Jenkins now we have switched to Gradle. I'm having a play with the patterns to see if that helps.

Notes:
*
*
*
