### PR TITLE
Remove automatic deploy to demo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -208,15 +208,6 @@ try {
 //                rpmTagger.tagDeploymentSuccessfulOn('test')
 //                rpmTagger.tagTestingPassedOn("test")
             }
-            stage('Deploy and Test on Demo') {
-                build job: 'document-deploy', parameters: [
-                        [$class: 'StringParameterValue', name: 'BUILD_APP', value: app],
-                        [$class: 'StringParameterValue', name: 'BUILD_VERSION', value: rpmVersion],
-                        [$class: 'StringParameterValue', name: 'ENVIRONMENT', value: 'demo']
-                ]
-//                rpmTagger.tagDeploymentSuccessfulOn('demo')
-//                rpmTagger.tagTestingPassedOn("demo")
-            }
         }
         stage('Slack Notification') {
             notifyBuildFixed channel: channel


### PR DESCRIPTION
Integration tests do not run properly on demo due to the
lack of IDAM testing end points so the build always fails.

