### PR TITLE
Gradle liquibase

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,8 @@ repositories {
     mavenLocal()
 }
 
+apply from: 'liquibase.gradle'
+
 def springBootVersion = plugins.getPlugin('org.springframework.boot').class.package.implementationVersion
 
 dependencyManagement {
@@ -138,6 +140,7 @@ dependencies {
     compile group: 'uk.gov.hmcts.reform.auth', name: 'auth-checker-lib', version: '2.1.1'
     compile group: 'uk.gov.hmcts.reform', name: 'java-logging-spring', version: '1.2.1'
     compile group: 'uk.gov.hmcts.reform', name: 'java-logging-httpcomponents', version: '1.2.1'
+    compile (group: 'org.liquibase', name: 'liquibase-core', version: "3.5.3")
 
     testCompile group: 'com.h2database', name: 'h2', version: '1.0.60'
     testCompile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.2.0'

--- a/liquibase.gradle
+++ b/liquibase.gradle
@@ -1,3 +1,4 @@
+
 configurations {
     liquibase
 }
@@ -13,13 +14,11 @@ liquibaseProps.load(new FileInputStream("src/main/resources/liquibase.properties
 task liquibaseDiffChangelog(type: JavaExec) {
     group = "liquibase"
 
-
     classpath sourceSets.main.runtimeClasspath
     classpath configurations.liquibase
     main = "liquibase.integration.commandline.Main"
 
-    args "--changeLogFile=" + liquibaseProps.getProperty('changeLogFile')
-//    args "--diffChangeLog=src/main/resources/db.changelog/db.changelog-diff-" + buildTimestamp() + ".xml"
+    args "--changeLogFile=" + "src/main/resources/db/changelog/db.changelog-diff-" + buildTimestamp() + ".xml"
     args "--referenceUrl=hibernate:spring:uk.gov.hmcts.dm.domain?dialect=org.hibernate.dialect.PostgreSQL94Dialect"
     args "--username=" + liquibaseProps.getProperty('username')
     args "--password=" + liquibaseProps.getProperty('password')

--- a/liquibase.gradle
+++ b/liquibase.gradle
@@ -1,0 +1,35 @@
+configurations {
+    liquibase
+}
+
+dependencies {
+    liquibase group: 'org.liquibase.ext', name: 'liquibase-hibernate5', version: 3.6
+}
+
+//loading properties file.
+Properties liquibaseProps = new Properties()
+liquibaseProps.load(new FileInputStream("src/main/resources/liquibase.properties"))
+
+task liquibaseDiffChangelog(type: JavaExec) {
+    group = "liquibase"
+
+
+    classpath sourceSets.main.runtimeClasspath
+    classpath configurations.liquibase
+    main = "liquibase.integration.commandline.Main"
+
+    args "--changeLogFile=" + liquibaseProps.getProperty('changeLogFile')
+//    args "--diffChangeLog=src/main/resources/db.changelog/db.changelog-diff-" + buildTimestamp() + ".xml"
+    args "--referenceUrl=hibernate:spring:uk.gov.hmcts.dm.domain?dialect=org.hibernate.dialect.PostgreSQL94Dialect"
+    args "--username=" + liquibaseProps.getProperty('username')
+    args "--password=" + liquibaseProps.getProperty('password')
+    args "--url=" + liquibaseProps.getProperty('url')
+    args "--driver=" + liquibaseProps.getProperty('driver')
+    args "diffChangeLog"
+}
+
+def buildTimestamp() {
+    def date = new Date()
+    def formattedDate = date.format('yyyyMMdd-HHmm')
+    return formattedDate
+}

--- a/src/main/resources/liquibase.properties
+++ b/src/main/resources/liquibase.properties
@@ -1,4 +1,5 @@
 changeLogFile=src/main/resources/db/changelog/db.changelog-master.xml
+#changelog.path=src/main/resources/db/changelog/
 # liquibase:generateChangeLog
 # http://www.liquibase.org/documentation/maven/maven_generateChangeLog.html
 # The target change log file to output to.
@@ -13,5 +14,6 @@ driver=org.postgresql.Driver
 #referenceDriver=org.postgresql.Driver
 #referenceUsername=evidence
 #referencePassword=evidence
-
+#domain.package=uk.gov.hmcts.dm.domain
+#hibernate.dialect=org.hibernate.dialect.PostgreSQL94Dialect
 referenceUrl=hibernate:spring:uk.gov.hmcts.dm.domain?dialect=org.hibernate.dialect.PostgreSQL94Dialect

--- a/src/main/resources/liquibase.properties
+++ b/src/main/resources/liquibase.properties
@@ -1,5 +1,4 @@
 changeLogFile=src/main/resources/db/changelog/db.changelog-master.xml
-#changelog.path=src/main/resources/db/changelog/
 # liquibase:generateChangeLog
 # http://www.liquibase.org/documentation/maven/maven_generateChangeLog.html
 # The target change log file to output to.
@@ -14,6 +13,5 @@ driver=org.postgresql.Driver
 #referenceDriver=org.postgresql.Driver
 #referenceUsername=evidence
 #referencePassword=evidence
-#domain.package=uk.gov.hmcts.dm.domain
-#hibernate.dialect=org.hibernate.dialect.PostgreSQL94Dialect
+
 referenceUrl=hibernate:spring:uk.gov.hmcts.dm.domain?dialect=org.hibernate.dialect.PostgreSQL94Dialect


### PR DESCRIPTION
Fixing Liquibase script generation after switching to Gradle.

Run `./gradlew liquibaseDiffChangeLog` to generate a new Liquibse script into `src/main/resources/db/changelog/db.changelog-diff-YYYYMMDD-HHMM.xml`.