### PR TITLE
Do not return deleted in searches

### DIFF
--- a/src/main/java/uk/gov/hmcts/dm/repository/StoredDocumentRepository.java
+++ b/src/main/java/uk/gov/hmcts/dm/repository/StoredDocumentRepository.java
@@ -18,10 +18,11 @@ import java.util.UUID;
 @Repository
 public interface StoredDocumentRepository extends PagingAndSortingRepository<StoredDocument, UUID> {
 
-    @Query("select s from StoredDocument s join s.metadata m where KEY(m) = :#{#metadataSearchCommand.name} and m = :#{#metadataSearchCommand.value}")
+    @Query("select s from StoredDocument s join s.metadata m where s.deleted = false and KEY(m) = :#{#metadataSearchCommand.name} and m = :#{#metadataSearchCommand.value}")
     Page<StoredDocument> findAllByMetadata(@NonNull @Param("metadataSearchCommand") MetadataSearchCommand metadataSearchCommand, @NonNull Pageable pageable);
 
 
-    Page<StoredDocument> findByCreatedBy(String creator, @NonNull Pageable pageable);
+    @Query("select s from StoredDocument s where s.deleted = false and s.createdBy = :#{#creator}")
+    Page<StoredDocument> findByCreatedBy(@Param("creator") String creator, @NonNull Pageable pageable);
 
 }

--- a/src/test/java/uk/gov/hmcts/dm/endtoend/SearchDocumentTest.java
+++ b/src/test/java/uk/gov/hmcts/dm/endtoend/SearchDocumentTest.java
@@ -1,0 +1,67 @@
+package uk.gov.hmcts.dm.endtoend;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.hmcts.dm.DmApp;
+import uk.gov.hmcts.dm.security.Classifications;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static uk.gov.hmcts.dm.endtoend.Helper.getBinaryUrlFromResponse;
+import static uk.gov.hmcts.dm.endtoend.Helper.getSelfUrlFromResponse;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = DmApp.class)
+@AutoConfigureMockMvc
+@ActiveProfiles("local")
+@TestPropertySource(
+    locations = "classpath:application-local.yaml")
+public class SearchDocumentTest {
+
+    public static final MockMultipartFile FILE =
+        new MockMultipartFile("files", "test.txt","text/plain", "test".getBytes(StandardCharsets.UTF_8));
+
+    @Autowired
+    private MockMvc mvc;
+    private HttpHeaders headers = Helper.getHeaders();
+
+    @Test
+    public void deleted_doc_should_not_appear_in_search() throws Exception {
+        final MockHttpServletResponse response = mvc.perform(fileUpload("/documents")
+            .file(FILE)
+            .param("classification", Classifications.PRIVATE.toString())
+            .headers(headers))
+            .andReturn().getResponse();
+
+        final String url = getSelfUrlFromResponse(response);
+
+        mvc.perform(post("/documents/owned?size=5&sort=createdOn,desc")
+            .headers(headers))
+            .andExpect(content().string(CoreMatchers.containsString(url)));
+
+        mvc.perform(delete(url)
+            .headers(headers))
+            .andExpect(status().is(204));
+
+        mvc.perform(post("/documents/owned?size=5&sort=createdOn,desc")
+            .headers(headers))
+            .andExpect(content().string(CoreMatchers.not(CoreMatchers.containsString(url))));
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/dm/endtoend/SearchDocumentTest.java
+++ b/src/test/java/uk/gov/hmcts/dm/endtoend/SearchDocumentTest.java
@@ -38,7 +38,7 @@ public class SearchDocumentTest {
 
     @Autowired
     private MockMvc mvc;
-    private HttpHeaders headers = Helper.getHeaders();
+    private final HttpHeaders headers = Helper.getHeaders();
 
     @Test
     public void deleted_doc_should_not_appear_in_search() throws Exception {

--- a/src/test/java/uk/gov/hmcts/dm/endtoend/SearchDocumentTest.java
+++ b/src/test/java/uk/gov/hmcts/dm/endtoend/SearchDocumentTest.java
@@ -18,10 +18,9 @@ import uk.gov.hmcts.dm.security.Classifications;
 
 import java.nio.charset.StandardCharsets;
 
-import static org.hamcrest.CoreMatchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-import static uk.gov.hmcts.dm.endtoend.Helper.getBinaryUrlFromResponse;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.dm.endtoend.Helper.getSelfUrlFromResponse;
 
 @RunWith(SpringRunner.class)


### PR DESCRIPTION
Deleted documents should not be returned in the search results.
