### PR TITLE
Fix missing bearer token log error

### DIFF
--- a/src/main/java/uk/gov/hmcts/dm/config/security/EmAuthCheckerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/dm/config/security/EmAuthCheckerConfiguration.java
@@ -19,42 +19,8 @@ import java.util.stream.Stream;
 @Configuration
 public class EmAuthCheckerConfiguration {
 
-//    @Bean
-//    public Function<HttpServletRequest, Optional<String>> userIdExtractor() {
-//        Pattern pattern = Pattern.compile("^/users/([^/]+)/.+$");
-//
-//        return request -> {
-//            Matcher matcher = pattern.matcher(request.getRequestURI());
-//            boolean matched = matcher.find();
-//            return Optional.ofNullable(matched ? matcher.group(1) : null);
-//        };
-//    }
-
-//    @Bean
-//    public Function<HttpServletRequest, Collection<String>> authorizedRolesExtractor() {
-//        return any -> Collections.emptyList();
-//    }
-
     @Bean
     public Function<HttpServletRequest, Collection<String>> authorizedServicesExtractor() {
         return any -> Stream.of("sscs", "divorce", "ccd", "em_gw").collect(Collectors.toList());
     }
-
-//    @Bean
-//    public AuthCheckerServiceAndUserFilter authCheckerServiceAndUserFilter(RequestAuthorizer<User> userRequestAuthorizer,
-//                                                                           RequestAuthorizer<Service> serviceRequestAuthorizer,
-//                                                                           AuthenticationManager authenticationManager) {
-//        AuthCheckerServiceAndUserFilter filter = new AuthCheckerServiceAndUserFilter(serviceRequestAuthorizer, userRequestAuthorizer);
-//        filter.setAuthenticationManager(authenticationManager);
-//        return filter;
-//    }
-
-    @Bean
-    public AuthCheckerServiceOnlyFilter authCheckerServiceFilter(RequestAuthorizer<Service> serviceRequestAuthorizer,
-                                                                        AuthenticationManager authenticationManager) {
-        AuthCheckerServiceOnlyFilter filter = new AuthCheckerServiceOnlyFilter(serviceRequestAuthorizer);
-        filter.setAuthenticationManager(authenticationManager);
-        return filter;
-    }
-
 }

--- a/src/main/java/uk/gov/hmcts/dm/config/security/SpringSecurityConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/dm/config/security/SpringSecurityConfiguration.java
@@ -12,6 +12,8 @@ import uk.gov.hmcts.reform.auth.checker.core.RequestAuthorizer;
 import uk.gov.hmcts.reform.auth.checker.core.service.Service;
 import uk.gov.hmcts.reform.auth.checker.spring.serviceonly.AuthCheckerServiceOnlyFilter;
 
+import java.util.Optional;
+
 import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
 
 /**
@@ -29,8 +31,8 @@ public class SpringSecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Autowired
     private AuthenticationManager authenticationManager;
 
-    @Autowired(required = false)
-    AuthCheckerServiceOnlyFilter serviceOnlyFilter;
+    @Autowired
+    Optional<AuthCheckerServiceOnlyFilter> serviceOnlyFilter;
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
@@ -62,12 +64,11 @@ public class SpringSecurityConfiguration extends WebSecurityConfigurerAdapter {
     }
 
     private AuthCheckerServiceOnlyFilter authCheckerServiceFilter() {
-        if (serviceOnlyFilter != null) {
-            return serviceOnlyFilter;
-        }
-        AuthCheckerServiceOnlyFilter filter = new AuthCheckerServiceOnlyFilter(serviceRequestAuthorizer);
-        filter.setAuthenticationManager(authenticationManager);
-        return filter;
+        return serviceOnlyFilter.orElseGet(() -> {
+            AuthCheckerServiceOnlyFilter filter = new AuthCheckerServiceOnlyFilter(serviceRequestAuthorizer);
+            filter.setAuthenticationManager(authenticationManager);
+            return filter;
+        });
     }
 
 

--- a/src/main/java/uk/gov/hmcts/dm/config/security/SpringSecurityConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/dm/config/security/SpringSecurityConfiguration.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.dm.config.security;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;

--- a/src/main/java/uk/gov/hmcts/dm/config/security/SpringSecurityConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/dm/config/security/SpringSecurityConfiguration.java
@@ -29,6 +29,9 @@ public class SpringSecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Autowired
     private AuthenticationManager authenticationManager;
 
+    @Autowired(required = false)
+    AuthCheckerServiceOnlyFilter serviceOnlyFilter;
+
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         AuthCheckerServiceOnlyFilter filter = authCheckerServiceFilter();
@@ -59,6 +62,9 @@ public class SpringSecurityConfiguration extends WebSecurityConfigurerAdapter {
     }
 
     private AuthCheckerServiceOnlyFilter authCheckerServiceFilter() {
+        if (serviceOnlyFilter != null) {
+            return serviceOnlyFilter;
+        }
         AuthCheckerServiceOnlyFilter filter = new AuthCheckerServiceOnlyFilter(serviceRequestAuthorizer);
         filter.setAuthenticationManager(authenticationManager);
         return filter;

--- a/src/main/java/uk/gov/hmcts/dm/config/security/SpringSecurityConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/dm/config/security/SpringSecurityConfiguration.java
@@ -31,18 +31,16 @@ public class SpringSecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Autowired
     private AuthenticationManager authenticationManager;
 
-    @Autowired
-    Optional<AuthCheckerServiceOnlyFilter> serviceOnlyFilter;
+    private AuthCheckerServiceOnlyFilter serviceOnlyFilter;
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        AuthCheckerServiceOnlyFilter filter = authCheckerServiceFilter();
-        filter.setAuthenticationManager(authenticationManager());
+        serviceOnlyFilter.setAuthenticationManager(authenticationManager());
 
         http.headers().cacheControl().disable();
 
         http
-            .addFilter(filter)
+            .addFilter(serviceOnlyFilter)
             .sessionManagement().sessionCreationPolicy(STATELESS).and()
             .csrf().disable()
             .formLogin().disable()
@@ -63,13 +61,12 @@ public class SpringSecurityConfiguration extends WebSecurityConfigurerAdapter {
                 "/info");
     }
 
-    private AuthCheckerServiceOnlyFilter authCheckerServiceFilter() {
-        return serviceOnlyFilter.orElseGet(() -> {
+    @Autowired
+    public void setServiceOnlyFilter(Optional<AuthCheckerServiceOnlyFilter> serviceOnlyFilter) {
+        this.serviceOnlyFilter = serviceOnlyFilter.orElseGet(() -> {
             AuthCheckerServiceOnlyFilter filter = new AuthCheckerServiceOnlyFilter(serviceRequestAuthorizer);
             filter.setAuthenticationManager(authenticationManager);
             return filter;
         });
     }
-
-
 }

--- a/src/main/java/uk/gov/hmcts/dm/config/security/SpringSecurityConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/dm/config/security/SpringSecurityConfiguration.java
@@ -1,11 +1,16 @@
 package uk.gov.hmcts.dm.config.security;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import uk.gov.hmcts.reform.auth.checker.core.RequestAuthorizer;
+import uk.gov.hmcts.reform.auth.checker.core.service.Service;
 import uk.gov.hmcts.reform.auth.checker.spring.serviceonly.AuthCheckerServiceOnlyFilter;
 
 import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
@@ -20,10 +25,14 @@ import static org.springframework.security.config.http.SessionCreationPolicy.STA
 public class SpringSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     @Autowired
-    private AuthCheckerServiceOnlyFilter filter;
+    private RequestAuthorizer<Service> serviceRequestAuthorizer;
+
+    @Autowired
+    private AuthenticationManager authenticationManager;
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
+        AuthCheckerServiceOnlyFilter filter = authCheckerServiceFilter();
         filter.setAuthenticationManager(authenticationManager());
 
         http.headers().cacheControl().disable();
@@ -35,14 +44,25 @@ public class SpringSecurityConfiguration extends WebSecurityConfigurerAdapter {
             .formLogin().disable()
             .logout().disable()
             .authorizeRequests()
-            .antMatchers("/swagger-ui.html",
-                    "/webjars/springfox-swagger-ui/**",
-                    "/swagger-resources/**",
-                    "/v2/**",
-                    "/health",
-                    "/info"
-            ).permitAll()
             .anyRequest().authenticated();
+    }
+
+    @Override
+    public void configure(WebSecurity web) {
+        web.ignoring()
+            .antMatchers("/swagger-ui.html",
+                "/webjars/springfox-swagger-ui/**",
+                "/swagger-resources/**",
+                "/v2/**",
+                "/favicon.ico",
+                "/health",
+                "/info");
+    }
+
+    private AuthCheckerServiceOnlyFilter authCheckerServiceFilter() {
+        AuthCheckerServiceOnlyFilter filter = new AuthCheckerServiceOnlyFilter(serviceRequestAuthorizer);
+        filter.setAuthenticationManager(authenticationManager);
+        return filter;
     }
 
 

--- a/src/test/java/uk/gov/hmcts/dm/componenttests/TestConfiguration.java
+++ b/src/test/java/uk/gov/hmcts/dm/componenttests/TestConfiguration.java
@@ -1,0 +1,21 @@
+package uk.gov.hmcts.dm.componenttests;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import uk.gov.hmcts.reform.auth.checker.core.RequestAuthorizer;
+import uk.gov.hmcts.reform.auth.checker.core.service.Service;
+import uk.gov.hmcts.reform.auth.checker.spring.serviceonly.AuthCheckerServiceOnlyFilter;
+
+@Configuration
+public class TestConfiguration {
+
+    @Bean
+    public AuthCheckerServiceOnlyFilter authCheckerServiceFilter(RequestAuthorizer<Service> serviceRequestAuthorizer,
+                                                                 AuthenticationManager authenticationManager) {
+        AuthCheckerServiceOnlyFilter filter = new AuthCheckerServiceOnlyFilter(serviceRequestAuthorizer);
+        filter.setAuthenticationManager(authenticationManager);
+        return filter;
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/dm/componenttests/TestConfiguration.java
+++ b/src/test/java/uk/gov/hmcts/dm/componenttests/TestConfiguration.java
@@ -15,6 +15,8 @@ public class TestConfiguration {
                                                                  AuthenticationManager authenticationManager) {
         AuthCheckerServiceOnlyFilter filter = new AuthCheckerServiceOnlyFilter(serviceRequestAuthorizer);
         filter.setAuthenticationManager(authenticationManager);
+        filter.setCheckForPrincipalChanges(true);
+        filter.setInvalidateSessionOnPrincipalChange(true);
         return filter;
     }
 


### PR DESCRIPTION
I had noticed in the Kibana logs that we have 'bearer token missing' a lot which was cluttering up the place. 
I managed to track it down to the auth checker filter being run for every request - even ones that Spring security wasn't supposed to manage.

I managed to track down the following StackOverflow question that said you can exclude url patterns from the Spring Security filter chain completely

https://stackoverflow.com/questions/30366405/how-to-disable-spring-security-for-particular-url

So now we do...

```java
    @Override
    public void configure(WebSecurity web) {
        web.ignoring()
            .antMatchers("/swagger-ui.html",
                "/webjars/springfox-swagger-ui/**",
                "/swagger-resources/**",
                "/v2/**",
                "/favicon.ico",
                "/health",
                "/info");
    }
```

This still didn't work so I found another Stackoverflow that pointed out that the filter cannot be a Spring managed bean as this is automatically be injected.

https://stackoverflow.com/questions/39152803/spring-websecurity-ignoring-doesnt-ignore-custom-filter

So now the auth checker filter is initialised within the Spring Security config.

```java
    @Override
    protected void configure(HttpSecurity http) throws Exception {
        AuthCheckerServiceOnlyFilter filter = authCheckerServiceFilter();
        filter.setAuthenticationManager(authenticationManager());

        http.headers().cacheControl().disable();

        http
            .addFilter(filter)
            .sessionManagement().sessionCreationPolicy(STATELESS).and()
            .csrf().disable()
            .formLogin().disable()
            .logout().disable()
            .authorizeRequests()
            .anyRequest().authenticated();
    }
```