### PR TITLE
Use ByteCode enhancement to lazily load content

### DIFF
--- a/src/main/java/uk/gov/hmcts/dm/domain/DocumentContentVersion.java
+++ b/src/main/java/uk/gov/hmcts/dm/domain/DocumentContentVersion.java
@@ -7,7 +7,6 @@ import lombok.Setter;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.LazyToOne;
 import org.hibernate.annotations.LazyToOneOption;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;

--- a/src/main/java/uk/gov/hmcts/dm/domain/DocumentContentVersion.java
+++ b/src/main/java/uk/gov/hmcts/dm/domain/DocumentContentVersion.java
@@ -5,6 +5,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.LazyToOne;
+import org.hibernate.annotations.LazyToOneOption;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -57,10 +60,11 @@ public class DocumentContentVersion implements RolesAware {
     @Temporal(TemporalType.TIMESTAMP)
     private Date createdOn;
 
-    @OneToOne(cascade = CascadeType.ALL, mappedBy = "documentContentVersion")
+    @OneToOne(cascade = CascadeType.ALL, mappedBy = "documentContentVersion", fetch = FetchType.LAZY)
     @Getter
     @Setter
     @JoinColumn(name = "document_content_version_id")
+    @LazyToOne(LazyToOneOption.NO_PROXY)
     private DocumentContent documentContent;
 
     @ManyToOne


### PR DESCRIPTION
`DocumentContent` was not being loaded lazily when we select the the `StoredDocument`.

It looks like `fetch = FetchType.LAZY` does not work for the parent association. It's explained quite nicely in the following link -

https://vladmihalcea.com/the-best-way-to-map-a-onetoone-relationship-with-jpa-and-hibernate/

This doesn't solve the problem of the data field not being loaded lazily but it makes sense to make `DocumentContent` lazy as it's only ever used when we get the binary of create a thumbnail.