### PR TITLE
Make caseworker permissioning more flexible

### DIFF
--- a/application/src/main/java/uk/gov/hmcts/dm/security/PermissionEvaluatorImpl.java
+++ b/application/src/main/java/uk/gov/hmcts/dm/security/PermissionEvaluatorImpl.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.dm.security;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.security.access.PermissionEvaluator;
 import org.springframework.security.core.Authentication;
@@ -16,7 +15,6 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.stream.Collectors;
 
 @Component

--- a/application/src/main/java/uk/gov/hmcts/dm/security/domain/DomainPermissionEvaluator.java
+++ b/application/src/main/java/uk/gov/hmcts/dm/security/domain/DomainPermissionEvaluator.java
@@ -11,15 +11,26 @@ import uk.gov.hmcts.dm.security.Permissions;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.stream.Collectors;
 
 @Component
 public class DomainPermissionEvaluator {
 
+    public static final String CASE_WORKER_PREFIX = "caseworker";
+
+    @Deprecated
     public boolean hasPermission(@NonNull final CreatorAware creatorAware,
                                  @NonNull final Permissions permission,
                                  final String authenticatedUserId,
                                  @NonNull final Collection<String> authenticatedUserRoles,
                                  @NonNull final Collection<String> caseWorkerRoles) {
+        return hasPermission(creatorAware, permission, authenticatedUserId, authenticatedUserRoles);
+    }
+
+    public boolean hasPermission(@NonNull final CreatorAware creatorAware,
+                                 @NonNull final Permissions permission,
+                                 final String authenticatedUserId,
+                                 @NonNull final Collection<String> authenticatedUserRoles) {
 
         boolean result = false;
 
@@ -45,14 +56,12 @@ public class DomainPermissionEvaluator {
         }
 
         if (!result && permission == Permissions.READ) {
+            boolean hasCaseworkerRole = !authenticatedUserRoles.stream()
+                .filter(role -> role.startsWith(CASE_WORKER_PREFIX))
+                .collect(Collectors.toList())
+                .isEmpty();
 
-            HashSet<String> authenticatedUserRolesSet = new HashSet<>(authenticatedUserRoles);
-
-            authenticatedUserRolesSet.retainAll(caseWorkerRoles);
-
-            if (authenticatedUserRolesSet.size() > 0) {
-                result = true;
-            }
+            result = hasCaseworkerRole;
         }
 
         return result;

--- a/application/src/main/java/uk/gov/hmcts/dm/security/domain/DomainPermissionEvaluator.java
+++ b/application/src/main/java/uk/gov/hmcts/dm/security/domain/DomainPermissionEvaluator.java
@@ -56,7 +56,7 @@ public class DomainPermissionEvaluator {
         }
 
         if (!result && permission == Permissions.READ) {
-            boolean hasCaseworkerRole = !authenticatedUserRoles.stream()
+            boolean hasCaseworkerRole = !new HashSet<>(authenticatedUserRoles).stream()
                 .filter(role -> role.startsWith(CASE_WORKER_PREFIX))
                 .collect(Collectors.toList())
                 .isEmpty();

--- a/application/src/main/resources/application.yaml
+++ b/application/src/main/resources/application.yaml
@@ -55,7 +55,6 @@ server:
   use-forward-headers: false
 
 authorization:
-  case-worker-roles: ${CASE_WORKER_ROLES:caseworker-probate,caseworker-cmc,caseworker-sscs,caseworker-divorce}
   s2s-names-whitelist: ${S2S_NAMES_WHITELIST:sscs,divorce,ccd,em_gw}
 
 auth:

--- a/application/src/test/java/uk/gov/hmcts/dm/security/domain/DomainPermissionEvaluatorTests.java
+++ b/application/src/test/java/uk/gov/hmcts/dm/security/domain/DomainPermissionEvaluatorTests.java
@@ -35,32 +35,28 @@ public class DomainPermissionEvaluatorTests {
                 storedFile,
                 Permissions.READ,
                 credentials,
-                Arrays.asList("granted", "x"),
-                Arrays.asList("granted", "y")
+                Arrays.asList("granted", "x")
             ));
         Assert.assertTrue(domainPermissionEvaluator
             .hasPermission(
                 storedFile,
                 Permissions.UPDATE,
                 credentials,
-                Arrays.asList("granted", "x"),
-                Arrays.asList("granted", "y")
+                Arrays.asList("granted", "x")
             ));
         Assert.assertTrue(domainPermissionEvaluator
             .hasPermission(
                 storedFile,
                 Permissions.CREATE,
                 credentials,
-                Arrays.asList("granted", "x"),
-                Arrays.asList("granted", "y")
+                Arrays.asList("granted", "x")
             ));
         Assert.assertTrue(domainPermissionEvaluator
             .hasPermission(
                 storedFile,
                 Permissions.DELETE,
                 credentials,
-                Arrays.asList("granted", "x"),
-                Arrays.asList("granted", "y")
+                Arrays.asList("granted", "x")
             ));
     }
 
@@ -77,32 +73,66 @@ public class DomainPermissionEvaluatorTests {
                 storedFile,
                 Permissions.READ,
                 caseWorkerCredentials,
-                Arrays.asList("case-worker", "x"),
-                Arrays.asList("case-worker", "y")
+                Arrays.asList("caseworker", "x")
             ));
         Assert.assertFalse(domainPermissionEvaluator
             .hasPermission(
                 storedFile,
                 Permissions.UPDATE,
                 caseWorkerCredentials,
-                Arrays.asList("case-worker", "x"),
-                Arrays.asList("case-worker", "y")
+                Arrays.asList("caseworker", "x")
             ));
         Assert.assertFalse(domainPermissionEvaluator
             .hasPermission(
                 storedFile,
                 Permissions.CREATE,
                 caseWorkerCredentials,
-                Arrays.asList("case-worker", "x"),
-                Arrays.asList("case-worker", "y")
+                Arrays.asList("caseworker", "x")
             ));
         Assert.assertFalse(domainPermissionEvaluator
             .hasPermission(
                 storedFile,
                 Permissions.DELETE,
                 caseWorkerCredentials,
-                Arrays.asList("case-worker", "x"),
-                Arrays.asList("case-worker", "y")
+                Arrays.asList("caseworker", "x")
+            ));
+    }
+
+    @Test
+    public void testAsADynamicCaseWorkerIHaveOnlyReadPermission() {
+        String caseWorkerCredentials = MRS_CASE_WORKER;
+
+        StoredDocument storedFile = new StoredDocument();
+        storedFile.setCreatedBy(MR_A);
+
+
+        Assert.assertTrue(domainPermissionEvaluator
+            .hasPermission(
+                storedFile,
+                Permissions.READ,
+                caseWorkerCredentials,
+                Arrays.asList("caseworker_123", "x")
+            ));
+        Assert.assertFalse(domainPermissionEvaluator
+            .hasPermission(
+                storedFile,
+                Permissions.UPDATE,
+                caseWorkerCredentials,
+                Arrays.asList("caseworker_123", "x")
+            ));
+        Assert.assertFalse(domainPermissionEvaluator
+            .hasPermission(
+                storedFile,
+                Permissions.CREATE,
+                caseWorkerCredentials,
+                Arrays.asList("caseworker_123", "x")
+            ));
+        Assert.assertFalse(domainPermissionEvaluator
+            .hasPermission(
+                storedFile,
+                Permissions.DELETE,
+                caseWorkerCredentials,
+                Arrays.asList("caseworker_123", "x")
             ));
     }
 
@@ -119,32 +149,28 @@ public class DomainPermissionEvaluatorTests {
                 storedFile,
                 Permissions.READ,
                 notCaseWorkerCredentials,
-                Arrays.asList("a", "x"),
-                Arrays.asList("case-worker", "y")
+                Arrays.asList("a", "x")
             ));
         Assert.assertFalse(domainPermissionEvaluator
             .hasPermission(
                 storedFile,
                 Permissions.UPDATE,
                 notCaseWorkerCredentials,
-                Arrays.asList("a", "x"),
-                Arrays.asList("case-worker", "y")
+                Arrays.asList("a", "x")
             ));
         Assert.assertFalse(domainPermissionEvaluator
             .hasPermission(
                 storedFile,
                 Permissions.CREATE,
                 notCaseWorkerCredentials,
-                Arrays.asList("a", "x"),
-                Arrays.asList("case-worker", "y")
+                Arrays.asList("a", "x")
             ));
         Assert.assertFalse(domainPermissionEvaluator
             .hasPermission(
                 storedFile,
                 Permissions.DELETE,
                 notCaseWorkerCredentials,
-                Arrays.asList("a", "x"),
-                Arrays.asList("case-worker", "y")
+                Arrays.asList("a", "x")
             ));
     }
 
@@ -160,8 +186,7 @@ public class DomainPermissionEvaluatorTests {
                 storedFile,
                 Permissions.READ,
                 MRS_CASE_WORKER,
-                Arrays.asList("allowingrole", "x"),
-                Arrays.asList("case-worker", "y")
+                Arrays.asList("allowingrole", "x")
             ));
     }
 
@@ -178,8 +203,7 @@ public class DomainPermissionEvaluatorTests {
                 storedFile,
                 Permissions.READ,
                 MRS_CASE_WORKER,
-                Arrays.asList("allowingrole", "x"),
-                Arrays.asList("case-worker", "y")
+                Arrays.asList("allowingrole", "x")
             ));
     }
 
@@ -197,8 +221,7 @@ public class DomainPermissionEvaluatorTests {
                 storedFile,
                 Permissions.READ,
                 MRS_CASE_WORKER,
-                Arrays.asList("allowingrole", "x"),
-                Arrays.asList("case-worker", "y")
+                Arrays.asList("allowingrole", "x")
             ));
     }
 
@@ -215,8 +238,7 @@ public class DomainPermissionEvaluatorTests {
                 storedFile,
                 Permissions.READ,
                 MRS_CASE_WORKER,
-                Arrays.asList("allowingrole", "x"),
-                Arrays.asList("case-worker", "y")
+                Arrays.asList("allowingrole", "x")
             ));
     }
 

--- a/functionalTests/src/functionalTest/groovy/uk/gov/hmcts/dm/functional/ReadDocumentIT.groovy
+++ b/functionalTests/src/functionalTest/groovy/uk/gov/hmcts/dm/functional/ReadDocumentIT.groovy
@@ -217,7 +217,7 @@ class ReadDocumentIT extends BaseIT {
     @Test
     void "R15 As authenticated user with a specific role I can't access a document if its CLASSIFICATION is PRIVATE and roles match"() {
 
-        def roles = ['caseworker']
+        def roles = ['not-a-caseworker']
 
         def documentUrl = createDocumentAndGetUrlAs CITIZEN, ATTACHMENT_9_JPG, 'PRIVATE', roles
 


### PR DESCRIPTION
The hardcoded list of caseworkers was too restrictive - requiring a redeployment if anyone adds a new caseworker jurisdiction. As a temporary solution until IDAM arrives, we check that the IDAM role starts with `caseworker`