### PR TITLE
Just log the error now we do not support ELK

### DIFF
--- a/application/src/main/java/uk/gov/hmcts/dm/errorhandler/ApiErrorAttributes.java
+++ b/application/src/main/java/uk/gov/hmcts/dm/errorhandler/ApiErrorAttributes.java
@@ -49,11 +49,7 @@ public class ApiErrorAttributes extends DefaultErrorAttributes {
         requestAttributes.setAttribute("javax.servlet.error.status_code", errorStatusCodeAndMessage.getStatusCode(), 0);
         errorAttributes.put("status", errorStatusCodeAndMessage.getStatusCode());
 
-        log.error(
-            errorStatusCodeAndMessage.getMessage(),
-            StructuredArguments.keyValue("errorCode", errorStatusCodeAndMessage.getMessage()),
-            StructuredArguments.keyValue("stackTrace", errorAttributes.get("trace"))
-        );
+        log.error(throwable.getMessage(), throwable);
 
         if (!globalIncludeStackTrace) {
             errorAttributes.remove("exception");


### PR DESCRIPTION
We don't need to do this now with AppInsights. It's also causing an error in the `java-logging` library because we're not passing in a proper `Exception` instance.
```uk.gov.hmcts.reform.logging.exception.InvalidExceptionImplementation:
   at uk.gov.hmcts.reform.logging.exception.AbstractLoggingException.triggerBadImplementationLog (AbstractLoggingException.java72)
   at uk.gov.hmcts.reform.logging.exception.AbstractLoggingException.getFromThrowableProxy (AbstractLoggingException.java53)
   at uk.gov.hmcts.reform.logging.provider.AbstractRequireJsonProvider.writeTo (AbstractRequireJsonProvider.java25)