### PR TITLE
Revert "Just log the error now we do not support ELK"

### DIFF
--- a/application/src/main/java/uk/gov/hmcts/dm/errorhandler/ApiErrorAttributes.java
+++ b/application/src/main/java/uk/gov/hmcts/dm/errorhandler/ApiErrorAttributes.java
@@ -49,7 +49,11 @@ public class ApiErrorAttributes extends DefaultErrorAttributes {
         requestAttributes.setAttribute("javax.servlet.error.status_code", errorStatusCodeAndMessage.getStatusCode(), 0);
         errorAttributes.put("status", errorStatusCodeAndMessage.getStatusCode());
 
-        log.error(throwable.getMessage(), throwable);
+        log.error(
+            errorStatusCodeAndMessage.getMessage(),
+            StructuredArguments.keyValue("errorCode", errorStatusCodeAndMessage.getMessage()),
+            StructuredArguments.keyValue("stackTrace", errorAttributes.get("trace"))
+        );
 
         if (!globalIncludeStackTrace) {
             errorAttributes.remove("exception");


### PR DESCRIPTION
Reverts hmcts/document-management-store-app#65

For some very weird reason it's breaking error tests....