### PR TITLE
Checkstyle: enable XML reports

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -66,7 +66,7 @@ pmd {
 //    Report Check Style added by Alex
 tasks.withType(Checkstyle) {
     reports {
-        xml.enabled false
+        xml.enabled true
         html.enabled true
     }
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RDM-2582


XML reports are easier for scripts to post process.  So enable them by
default.




**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```