### PR TITLE
RDM-2564: Upgrade to Gradle 4.9

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -11,6 +11,7 @@ plugins {
     id 'jacoco'
     id 'idea'
     id 'eclipse'
+    id 'io.franzbecker.gradle-lombok' version '1.14'
 }
 
 group = 'uk.gov.hmcts.reform.dm'
@@ -144,7 +145,7 @@ dependencies {
 
     compile group: 'org.postgresql', name: 'postgresql', version: versions.postgresqlVersion
 
-    compile group: 'org.projectlombok', name: 'lombok', version: versions.lombok
+    compileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
 
     compile group: 'uk.gov.hmcts.reform.auth', name: 'auth-checker-lib', version: '2.1.3'
     compile group: 'uk.gov.hmcts.reform', name: 'java-logging-spring', version: '2.1.1'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-2564

### Change description ###

Upgrade to Gradle 4.9 to align with Docker Hub
Add Lombok plugin to fix compatibility issue

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No