### PR TITLE
[PREVIEW] Upgrade Spring Boot to 1.5.15 to address CVE issues

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'checkstyle'
     id 'pmd'
     id 'io.spring.dependency-management' version '1.0.5.RELEASE'
-    id 'org.springframework.boot' version '1.5.12.RELEASE'
+    id 'org.springframework.boot' version '1.5.15.RELEASE'
     id 'org.owasp.dependencycheck' version '3.2.1'
     id 'se.patrikerdes.use-latest-versions' version '0.2.3'
     id 'com.github.ben-manes.versions' version '0.19.0'
@@ -127,7 +127,7 @@ dependencies {
 
     compile group: 'org.ehcache', name: 'ehcache', version: versions.ehcache
 
-    compile group: 'org.springframework', name: 'spring-context-support', version: '4.3.8.RELEASE'
+    compile group: 'org.springframework', name: 'spring-context-support', version: '4.3.18.RELEASE'
     compile group: 'org.springframework.boot', name: 'spring-boot-devtools', version: versions.springBoot
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: versions.springBoot
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-aop', version: versions.springBoot

--- a/functionalTests/build.gradle
+++ b/functionalTests/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'groovy'
     id 'java'
     id 'idea'
-    id 'org.springframework.boot' version '1.5.7.RELEASE'
+    id 'org.springframework.boot' version '1.5.15.RELEASE'
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8

--- a/smokeTests/build.gradle
+++ b/smokeTests/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'groovy'
     id 'java'
     id 'idea'
-    id 'org.springframework.boot' version '1.5.7.RELEASE'
+    id 'org.springframework.boot' version '1.5.15.RELEASE'
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
This addresses CVE-2018-11039 and CVE-2018-11040 which are present in
"Spring Framework, versions 5.0.x prior to 5.0.7 and 4.3.x prior to
4.3.18 and older unsupported versions"

https://nvd.nist.gov/vuln/detail/CVE-2018-11039
https://nvd.nist.gov/vuln/detail/CVE-2018-11040




https://tools.hmcts.net/jira/browse/RDM-2831





**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes - we're bumping spring so yes potentially
[ ] No
```