### PR TITLE
[PREVIEW] RDM-2869 Configure EnableGlobalMethodSecurity 

### DIFF
--- a/application/src/main/java/uk/gov/hmcts/dm/config/security/MethodSecurityConfig.java
+++ b/application/src/main/java/uk/gov/hmcts/dm/config/security/MethodSecurityConfig.java
@@ -1,0 +1,10 @@
+package uk.gov.hmcts.dm.config.security;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.GlobalMethodSecurityConfiguration;
+
+@Configuration
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+public class MethodSecurityConfig extends GlobalMethodSecurityConfiguration {
+}

--- a/application/src/main/java/uk/gov/hmcts/dm/config/security/SpringSecurityConfiguration.java
+++ b/application/src/main/java/uk/gov/hmcts/dm/config/security/SpringSecurityConfiguration.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.dm.config.security;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -18,7 +17,6 @@ import static org.springframework.security.config.http.SessionCreationPolicy.STA
 
 @Configuration
 @EnableWebSecurity
-@EnableGlobalMethodSecurity(prePostEnabled = true)
 public class SpringSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     @Autowired


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-2869


### Change description ###
As recommended by spring users moved EnableGlobalMethodSecurity annotation to be on GlobalMethodSecurityConfiguration.
GlobalMethodSecurityConfiguration implements SmartInitializingSingleton
https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/beans/factory/SmartInitializingSingleton.html

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
