### PR TITLE
TO-BE -DELETED Storing new documentContentVersion to BlobStore

### DIFF
--- a/application/src/main/java/uk/gov/hmcts/dm/service/StoredDocumentService.java
+++ b/application/src/main/java/uk/gov/hmcts/dm/service/StoredDocumentService.java
@@ -146,6 +146,11 @@ public class StoredDocumentService {
                                                                                    azureStorageConfiguration
                                                                                        .isPostgresBlobStorageEnabled());
         documentContentVersionRepository.save(documentContentVersion);
+        if (azureStorageConfiguration.isAzureBlobStoreEnabled()) {
+            blobStorageWriteService.uploadDocumentContentVersion(storedDocument,
+                documentContentVersion,
+                file);
+        }
         storedDocument.getDocumentContentVersions().add(documentContentVersion);
         return documentContentVersion;
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-3121


### Change description ###
Add new documentContentVersion will now store it to Blob Store when enabled


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
