### PR TITLE
[PREVIEW] Infra: use CCD shared infrastructure

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -18,8 +18,8 @@ locals {
   nonPreviewVaultName = "${var.raw_product}-${var.env}"
   vaultName = "${(var.env == "preview" || var.env == "spreview") ? local.previewVaultName : local.nonPreviewVaultName}"
 
-  sharedAppServicePlan = "${var.raw_product}-${var.env}"
-  sharedASPResourceGroup = "${var.raw_product}-shared-${var.env}"
+  sharedAppServicePlan = "${var.shared_product}-${var.env}"
+  sharedASPResourceGroup = "${var.shared_product}-shared-${var.env}"
 }
 
 module "app" {

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -6,6 +6,11 @@ variable "raw_product" {
   default = "dm" // jenkins-library overrides product for PRs and adds e.g. pr-118-dm
 }
 
+variable "shared_product" {
+  // We use CCD as our common shared product for any shared infra
+  default = "ccd"
+}
+
 variable "component" {
   type = "string"
 }


### PR DESCRIPTION
We don't need to maintain multiple shared infrastructures and since we
only have one 'dm' app, use the shared ASP from ccd-shared-$env.





https://tools.hmcts.net/jira/browse/RDM-2635





**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```