### PR TITLE
Upgrade to version 1.19.1 of Apache Tika

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -116,7 +116,7 @@ def versions = [
 dependencies {
     compile group: 'com.microsoft.azure', name: 'azure-storage', version: '8.0.0'
     compile group: 'org.apache.pdfbox', name: 'pdfbox', version: '2.0.9'
-    compile group: 'org.apache.tika', name: 'tika-core', version: '1.18'
+    compile group: 'org.apache.tika', name: 'tika-core', version: '1.19.1'
     compile group: 'org.apache.tomcat', name: 'tomcat-annotations-api', version: '9.0.8'
 
     compile group: 'commons-io', name: 'commons-io', version: '2.6'

--- a/application/src/main/java/uk/gov/hmcts/dm/service/BlobStorageMigrationService.java
+++ b/application/src/main/java/uk/gov/hmcts/dm/service/BlobStorageMigrationService.java
@@ -98,7 +98,7 @@ public class BlobStorageMigrationService {
             new PageRequest(0, limit, DESC, "createdOn"));
 
         if (!mockRun) {
-            dcvList.forEach(dcv -> migrateDocumentContentVersion(dcv));
+            dcvList.forEach(this::migrateDocumentContentVersion);
         }
 
         MigrateProgressReport after = getMigrateProgressReport();


### PR DESCRIPTION
Addresses security vulnerability CVE-2018-8017.




https://tools.hmcts.net/jira/browse/RDM-3296





**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```