### PR TITLE
RDM-3351: Disable TTL in all envs

### DIFF
--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -31,7 +31,7 @@ enable_metadata_search = "true"
 enable_document_and_metadata_upload = "false"
 enable_folder_api = "true"
 enable_delete = "true"
-enable_ttl  = "true"
+enable_ttl  = "false"
 enable_thumbnail = "true"
 
 ////////////////////////////////////////////////

--- a/infrastructure/demo.tfvars
+++ b/infrastructure/demo.tfvars
@@ -29,7 +29,7 @@ enable_metadata_search = "true"
 enable_document_and_metadata_upload = "false"
 enable_folder_api = "true"
 enable_delete = "true"
-enable_ttl  = "true"
+enable_ttl  = "false"
 enable_thumbnail = "true"
 
 enable_postgres_blob_storage = "false"

--- a/infrastructure/preview.tfvars
+++ b/infrastructure/preview.tfvars
@@ -26,7 +26,7 @@ enable_metadata_search = "true"
 enable_document_and_metadata_upload = "false"
 enable_folder_api = "true"
 enable_delete = "true"
-enable_ttl  = "true"
+enable_ttl  = "false"
 enable_thumbnail = "true"
 
 enable_postgres_blob_storage = "false"

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -31,7 +31,7 @@ enable_metadata_search = "true"
 enable_document_and_metadata_upload = "false"
 enable_folder_api = "true"
 enable_delete = "true"
-enable_ttl  = "true"
+enable_ttl  = "false"
 enable_thumbnail = "true"
 
 ////////////////////////////////////////////////

--- a/infrastructure/sandbox.tfvars
+++ b/infrastructure/sandbox.tfvars
@@ -26,7 +26,7 @@ enable_metadata_search = "true"
 enable_document_and_metadata_upload = "true"
 enable_folder_api = "true"
 enable_delete = "true"
-enable_ttl  = "true"
+enable_ttl  = "false"
 enable_thumbnail = "true"
 
 ////////////////////////////////////////////////

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -143,7 +143,7 @@ variable "enable_delete" {
 }
 
 variable "enable_ttl" {
-    default = "true"
+    default = "false"
 }
 
 variable "enable_thumbnail" {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-3351

### Change description ###

Disable TTL feature for all envs.
Impact is:
* On document creation, the TTL will be ignored and not saved with the document
* On document update, the TTL will be saved
* For existing documents with a TTL, they will only be deleted when the TTL feature is re-enabled

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```