### PR TITLE
Bump dependency-management from 1.0.5.RELEASE to 1.0.6.RELEASE in /application

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'application'
     id 'checkstyle'
     id 'pmd'
-    id 'io.spring.dependency-management' version '1.0.5.RELEASE'
+    id 'io.spring.dependency-management' version '1.0.6.RELEASE'
     id 'org.springframework.boot' version '1.5.15.RELEASE'
     id 'org.owasp.dependencycheck' version '3.3.2'
     id 'se.patrikerdes.use-latest-versions' version '0.2.3'


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RDM-2846





**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```