### PR TITLE
Fix Swagger publishing

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -287,3 +287,8 @@ run {
         jvmArgs = ['-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005']
     }
 }
+
+task installDist(overwrite: true) {
+    // This task must be overwritten to do as it's breaking JAR packaging and it's a mandatory step of swagger
+    // documentation publication.
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Override gradle's installDist task as it's breaking JAR packaging
preventing publishing of Swagger specs

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```