### PR TITLE
Remove sscs_bulkscan to force Terraform to update

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -185,7 +185,7 @@ variable "dm_multipart_whitelist_ext" {
 }
 
 variable "s2s_names_whitelist" {
-  default = "em_api,em_gw,ccd_gw,ccd_data,sscs,sscs_bulkscan,divorce_document_upload,divorce_frontend,divorce_document_generator,probate_backend,jui_webapp,pui_webapp,cmc_claim_store,bulk_scan_processor,em_npa_app,bulk_scan_orchestrator,fpl_case_service,finrem_document_generator"
+  default = "em_api,em_gw,ccd_gw,ccd_data,sscs,divorce_document_upload,divorce_frontend,divorce_document_generator,probate_backend,jui_webapp,pui_webapp,cmc_claim_store,bulk_scan_processor,em_npa_app,bulk_scan_orchestrator,fpl_case_service,finrem_document_generator"
 }
 
 variable "case_worker_roles" {


### PR DESCRIPTION
Due some strange error builds we have:
1. Code with 'sscs_bulkscan'
2. Succesful builds
3. State file on Azure with that value added
4. Webapp without that value.

Plan is to:
a. Remove 'sscs_bulkscan' and allow Terraform to update the webapp
b. Readd 'sscs_bulkscan' and allow Terraform to correctly set the value
in the webapp.




https://tools.hmcts.net/jira/browse/RDM-3661





**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```