### PR TITLE
Enable local cache

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -45,7 +45,7 @@ module "app" {
   common_tags  = "${var.common_tags}"
   asp_name = "${(var.asp_name == "use_shared") ? local.sharedAppServicePlan : var.asp_name}"
   asp_rg = "${(var.asp_rg == "use_shared") ? local.sharedASPResourceGroup : var.asp_rg}"
-  website_local_cache_sizeinmb = 0
+  website_local_cache_sizeinmb = 1600
 
   app_settings = {
     POSTGRES_HOST = "${module.db.host_name}"


### PR DESCRIPTION
### JIRA link (if applicable) ###
Some P1 incident...


### Change description ###
Microsoft have recommended enabling local cache on this app,
actual number can be debated if you wish, I just picked a reasonably big one...

Excerpt from an email from support ticket:
```
I discussed with one of our Java folks, and I believe what is happening is that the site is hitting file i/o contention when the deployment happens. 
This would explain why the prod slot is hit with the timeouts right while the deployment to staging is happening. 
Java apps tend to be relatively file i/o-intensive, and this becomes significantly more noticeable in platforms that use file shares to serve the app content (such as in Azure App Service), 
due to the network hops between the vms and file server. 
I see that the site content that is deployed is around 400MB and takes several minutes to deploy, which signifies i/o-intensive activity. 
The Apps in the same ASE will share the same file server (and there isn’t way to change or add file servers), so the deployment is likely to impact i/o operations on other sites.
 
In such situations, we recommend using Local Cache if possible since this will store a full copy of the site contents on the VM. 
However, Local Cache is only an option if the site does not write permanent data to the local file system in the app (apart from App Service logs to d:\home\logfiles).
```








**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
