### PR TITLE
Bump tika-core from 1.19.1 to 1.20

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -116,7 +116,7 @@ def versions = [
 dependencies {
     compile group: 'com.microsoft.azure', name: 'azure-storage', version: '8.0.0'
     compile group: 'org.apache.pdfbox', name: 'pdfbox', version: '2.0.13'
-    compile group: 'org.apache.tika', name: 'tika-core', version: '1.19.1'
+    compile group: 'org.apache.tika', name: 'tika-core', version: '1.20'
     compile group: 'org.apache.tomcat', name: 'tomcat-annotations-api', version: '9.0.8'
 
     compile group: 'commons-io', name: 'commons-io', version: '2.6'


### PR DESCRIPTION
We don't use the SQLite3Parser but upgrade anyway.

See
https://nvd.nist.gov/vuln/detail/CVE-2018-17197
https://lists.apache.org/thread.html/7c021a4ea2037e52e74628e17e8e0e2acab1f447160edc8be0eae6d3@%3Cdev.tika.apache.org%3E



### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-4397


### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```