### PR TITLE
Bump jackson databind to v2.9.9 to address CVE-2019-12086

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -100,7 +100,7 @@ dependencyManagement {
 def versions = [
     ehcache            : '3.5.2',
     jacocoMavenPlugin  : '0.7.9',
-    jackson            : '2.9.8',
+    jackson            : '2.9.9',
     jetty              : '9.4.11.v20180605',
     jsonUnit           : '1.31.1',
     JUnitParams        : '1.1.1',


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-4823


### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```