### PR TITLE
Bump spring boot to 1.5.21

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'checkstyle'
     id 'pmd'
     id 'io.spring.dependency-management' version '1.0.6.RELEASE'
-    id 'org.springframework.boot' version '1.5.19.RELEASE'
+    id 'org.springframework.boot' version '1.5.21.RELEASE'
     id 'org.owasp.dependencycheck' version '3.3.2'
     id 'se.patrikerdes.use-latest-versions' version '0.2.7'
     id 'com.github.ben-manes.versions' version '0.20.0'


### PR DESCRIPTION
Addresses CVE-2019-0221 related to tomcat server issues.


### JIRA link (if applicable) ###




### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```