### PR TITLE
remove redundant properties after spring 2.0 upgrade

### DIFF
--- a/application/src/main/resources/application.yaml
+++ b/application/src/main/resources/application.yaml
@@ -68,10 +68,6 @@ auth:
       client:
         baseUrl: ${IDAM_S2S_BASE_URI:http://localhost:4502}
 
-security:
-  headers:
-    cache: false
-
 logging:
   level:
     org.springframework.web: ${LOG_LEVEL_SPRING_WEB:DEBUG}
@@ -114,12 +110,6 @@ health:
     - UP
   disk:
     threshold: ${HEALTH_DISK_THRESHOLD:262144000}
-
-endpoints:
-  health:
-    sensitive: ${ENDPOINTS_HEALTH_SENSITIVE:false}
-  info:
-    sensitive: ${ENDPOINTS_INFO_SENSITIVE:false}
 
 management:
   endpoint:

--- a/application/src/test/resources/application-local.yaml
+++ b/application/src/test/resources/application-local.yaml
@@ -2,8 +2,8 @@ spring:
   database:
     driverClassName: org.h2.Driver
   datasource:
-#    url: jdbc:h2:mem:test_mem
-    url: jdbc:h2:build/h2_db/test;DB_CLOSE_ON_EXIT=FALSE
+    url: jdbc:h2:mem:test_mem
+#    url: jdbc:h2:build/h2_db/test;DB_CLOSE_ON_EXIT=FALSE
     platform: h2
   jpa:
     database-platform: uk.gov.hmcts.dm.dialect.CustomH2Dialect

--- a/charts/dm-store/values.yaml
+++ b/charts/dm-store/values.yaml
@@ -54,9 +54,6 @@ java:
     SHOW_SQL: 'false'
     JSON_CONSOLE_PRETTY_PRINT: 'false'
 
-    ENDPOINTS_HEALTH_SENSITIVE: 'true'
-    ENDPOINTS_INFO_SENSITIVE: 'true'
-
     ENABLE_DB_MIGRATE: 'true'
 
     DM_MULTIPART_WHITELIST: 'image/jpeg,application/pdf,image/tiff,image/png,image/bmp,text/plain,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.openxmlformats-officedocument.wordprocessingml.template,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.openxmlformats-officedocument.spreadsheetml.template,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.openxmlformats-officedocument.presentationml.template,application/vnd.openxmlformats-officedocument.presentationml.slideshow,application/rtf,text/csv'

--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -23,8 +23,6 @@ root_logging_level = "INFO"
 log_level_spring_web = "INFO"
 log_level_dm = "INFO"
 show_sql = "false"
-endpoints_health_sensitive = "true"
-endpoints_info_sensitive = "true"
 
 ////////////////////////////////////////////////
 // Toggle Features

--- a/infrastructure/demo.tfvars
+++ b/infrastructure/demo.tfvars
@@ -22,8 +22,6 @@ root_logging_level = "INFO"
 log_level_spring_web = "INFO"
 log_level_dm = "INFO"
 show_sql = "false"
-endpoints_health_sensitive = "true"
-endpoints_info_sensitive = "true"
 
 ////////////////////////////////////////////////
 // Toggle Features

--- a/infrastructure/ithc.tfvars
+++ b/infrastructure/ithc.tfvars
@@ -22,8 +22,6 @@ root_logging_level = "INFO"
 log_level_spring_web = "INFO"
 log_level_dm = "INFO"
 show_sql = "false"
-endpoints_health_sensitive = "true"
-endpoints_info_sensitive = "true"
 
 ////////////////////////////////////////////////
 // Toggle Features

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -88,8 +88,6 @@ module "app" {
     LOG_LEVEL_DM = "${var.log_level_dm}"
     SHOW_SQL = "${var.show_sql}"
 
-    ENDPOINTS_HEALTH_SENSITIVE = "${var.endpoints_health_sensitive}"
-    ENDPOINTS_INFO_SENSITIVE = "${var.endpoints_info_sensitive}"
 
     ENABLE_DB_MIGRATE="false"
 

--- a/infrastructure/perftest.tfvars
+++ b/infrastructure/perftest.tfvars
@@ -22,8 +22,6 @@ root_logging_level = "INFO"
 log_level_spring_web = "INFO"
 log_level_dm = "INFO"
 show_sql = "false"
-endpoints_health_sensitive = "true"
-endpoints_info_sensitive = "true"
 
 ////////////////////////////////////////////////
 // Toggle Features

--- a/infrastructure/preview.tfvars
+++ b/infrastructure/preview.tfvars
@@ -14,8 +14,6 @@ root_logging_level = "INFO"
 log_level_spring_web = "INFO"
 log_level_dm = "INFO"
 show_sql = "false"
-endpoints_health_sensitive = "true"
-endpoints_info_sensitive = "true"
 
 ////////////////////////////////////////////////
 // Toggle Features

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -22,8 +22,6 @@ root_logging_level = "INFO"
 log_level_spring_web = "INFO"
 log_level_dm = "INFO"
 show_sql = "false"
-endpoints_health_sensitive = "true"
-endpoints_info_sensitive = "true"
 
 ////////////////////////////////////////////////
 // Toggle Features

--- a/infrastructure/sandbox.tfvars
+++ b/infrastructure/sandbox.tfvars
@@ -14,8 +14,6 @@ root_logging_level = "INFO"
 log_level_spring_web = "INFO"
 log_level_dm = "INFO"
 show_sql = "true"
-endpoints_health_sensitive = "true"
-endpoints_info_sensitive = "true"
 
 ////////////////////////////////////////////////
 // Toggle Features

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -114,13 +114,6 @@ variable "show_sql" {
   default = "true"
 }
 
-variable "endpoints_health_sensitive" {
-  default = "true"
-}
-
-variable "endpoints_info_sensitive" {
-  default = "true"
-}
 ////////////////////////////////////////////////
 // Toggle Features
 ////////////////////////////////////////////////


### PR DESCRIPTION
I ran the spring-boot-properties-migrator plugin and found we had a couple of redundant properties.