### PR TITLE
Moving to hmcts version of liquibase which performs better DB locking

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -109,7 +109,7 @@ def versions = [
     jsonUnit           : '1.31.1',
     JUnitParams        : '1.1.1',
     lombok             : '1.18.0',
-    liquibase          : '3.6.3',
+    liquibase          : '3.8.1',
     postgresql         : '42.2.6',
     powermock          : '1.7.4',
     sonar              : '3.2',
@@ -147,7 +147,7 @@ dependencies {
 
     compile group: 'org.hibernate', name: 'hibernate-core', version: '5.4.8.Final'
 
-    compile group: 'org.liquibase', name: 'liquibase-core', version: versions.liquibaseVersion
+    compile group: 'uk.gov.hmcts.reform', name: 'liquibase-core', version: '3.8.1'
 
     compile group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
     compile group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger

--- a/application/liquibase.gradle
+++ b/application/liquibase.gradle
@@ -4,7 +4,7 @@ configurations {
 }
 
 dependencies {
-    liquibase group: 'org.liquibase.ext', name: 'liquibase-hibernate5', version: 3.6
+    liquibase group: 'org.liquibase.ext', name: 'liquibase-hibernate5', version: 3.8
 }
 
 //loading properties file.
@@ -33,7 +33,7 @@ task migratePostgresDatabase(type: JavaExec) {
     classpath sourceSets.main.runtimeClasspath
     classpath configurations.liquibase
     main = "liquibase.integration.commandline.Main"
-
+    systemProperty "liquibase.useDbLock", true
     def urlString = project.hasProperty("dburl") ? "jdbc:postgresql://$dburl" : liquibaseProps.getProperty('url')
     def user = project.hasProperty("flyway.user") ? "${rootProject.properties['flyway.user']}" : liquibaseProps.getProperty('username')
     def password = project.hasProperty("flyway.password") ? "${rootProject.properties['flyway.password']}" : liquibaseProps.getProperty('password')

--- a/application/src/main/java/uk/gov/hmcts/dm/DmApp.java
+++ b/application/src/main/java/uk/gov/hmcts/dm/DmApp.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.dm;
 
+import liquibase.configuration.GlobalConfiguration;
+import liquibase.configuration.LiquibaseConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
@@ -14,6 +16,10 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 public class DmApp {
 
     public static void main(String[] args) {
+        //Setting Liquibase DB Lock property before Spring starts up.
+        LiquibaseConfiguration.getInstance()
+            .getConfiguration(GlobalConfiguration.class)
+            .setUseDbLock(true);
         SpringApplication.run(DmApp.class, args);
     }
 }


### PR DESCRIPTION
This based on https://github.com/hmcts/liquibase/pull/2

PR Logs : 

kubectl logs dm-store-pr-442-java-689f8c69c-slxd2 -n dm-store | grep advisory
2019-11-14T16:57:03.262 INFO  [main] liquibase.executor.jvm.JdbcExecutor select pg_try_advisory_lock(1333202681,-198448342)
2019-11-14T16:57:04.667 INFO  [main] liquibase.executor.jvm.JdbcExecutor select pg_advisory_unlock(1333202681,-198448342)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
