### PR TITLE
remove client mime-type check

### DIFF
--- a/application/src/test/java/uk/gov/hmcts/dm/controller/StoredDocumentControllerTests.java
+++ b/application/src/test/java/uk/gov/hmcts/dm/controller/StoredDocumentControllerTests.java
@@ -137,7 +137,7 @@ public class StoredDocumentControllerTests extends ComponentTestBase {
     public void testCreateFromDocumentsWithNonWhitelistFile() throws Exception {
         List<MultipartFile> files = Stream.of(
             new MockMultipartFile("files", "filename.txt", "text/plain", "hello".getBytes(StandardCharsets.UTF_8)),
-            new MockMultipartFile("files", "filename.txt", "", "hello2".getBytes(StandardCharsets.UTF_8)))
+            new MockMultipartFile("files", "filename.exe", "", "hello2".getBytes(StandardCharsets.UTF_8)))
             .collect(Collectors.toList());
 
         List<StoredDocument> storedDocuments = files.stream()

--- a/application/src/test/java/uk/gov/hmcts/dm/service/FileContentVerifierTests.java
+++ b/application/src/test/java/uk/gov/hmcts/dm/service/FileContentVerifierTests.java
@@ -54,12 +54,6 @@ public class FileContentVerifierTests {
     }
 
     @Test
-    public void testUploadTikaDetectionFailure() throws Exception {
-        MultipartFile file = new MockMultipartFile("files", "filename.txt", "text/plain", getClass().getClassLoader().getResourceAsStream(EXAMPLE_PDF_FILE));
-        assertFalse(fileContentVerifier.verifyContentType(file));
-    }
-
-    @Test
     public void testInputException() throws Exception {
         MultipartFile file = Mockito.mock(MockMultipartFile.class);
         Mockito.when(file.getContentType()).thenReturn("application/pdf");
@@ -80,9 +74,9 @@ public class FileContentVerifierTests {
     }
 
     @Test
-    public void testUploadMimeTypeAllowedButDoesNotMatchActualType() throws Exception {
+    public void testIgnoreClientMimeType() throws Exception {
         MultipartFile file = new MockMultipartFile("files", "filename.txt", "tex", getClass().getClassLoader().getResourceAsStream(EXAMPLE_PDF_FILE));
-        assertFalse(fileContentVerifier.verifyContentType(file));
+        assertTrue(fileContentVerifier.verifyContentType(file));
     }
 
     @Test

--- a/config/owasp/dependency-check-suppressions.xml
+++ b/config/owasp/dependency-check-suppressions.xml
@@ -284,5 +284,7 @@ Another long cpe again
         <cve>CVE-2019-16942</cve>
         <cve>CVE-2019-16943</cve>
         <cve>CVE-2019-17267</cve>
+        <cve>CVE-2019-12418</cve>
+        <cve>CVE-2019-17563</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
This PR disables the check that ensures the client content type matches the one tika detects locally. 

This check adds no value as we should never trust anything a client sends.