### PR TITLE
remove transactional annotations

### DIFF
--- a/application/src/main/java/uk/gov/hmcts/dm/DmApp.java
+++ b/application/src/main/java/uk/gov/hmcts/dm/DmApp.java
@@ -6,12 +6,14 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.circuitbreaker.EnableCircuitBreaker;
 import org.springframework.cloud.netflix.hystrix.dashboard.EnableHystrixDashboard;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @SpringBootApplication
 @EnableSwagger2
 @EnableCircuitBreaker
 @EnableHystrixDashboard
+@EnableScheduling
 @SuppressWarnings("HideUtilityClassConstructor") // Spring needs a constructor, its not a utility class
 public class DmApp {
 

--- a/application/src/main/java/uk/gov/hmcts/dm/config/batch/BatchConfiguration.java
+++ b/application/src/main/java/uk/gov/hmcts/dm/config/batch/BatchConfiguration.java
@@ -8,7 +8,9 @@ import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.JobParametersInvalidException;
 import org.springframework.batch.core.Step;
-import org.springframework.batch.core.configuration.annotation.*;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
 import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
@@ -17,16 +19,13 @@ import org.springframework.batch.item.database.JpaItemWriter;
 import org.springframework.batch.item.database.JpaPagingItemReader;
 import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.transaction.PlatformTransactionManager;
 import uk.gov.hmcts.dm.domain.StoredDocument;
 
 import javax.persistence.EntityManagerFactory;
@@ -58,21 +57,8 @@ public class BatchConfiguration {
     @Autowired
     JdbcTemplate jdbcTemplate;
 
-    @Autowired
-    @Qualifier("transactionManager") PlatformTransactionManager transactionManager;
-
     @Value("${spring.batch.historicExecutionsRetentionMilliseconds}")
     int historicExecutionsRetentionMilliseconds;
-
-    @Bean
-    public BatchConfigurer batchConfigurer(EntityManagerFactory emf) {
-        return new DefaultBatchConfigurer() {
-            @Override
-            public PlatformTransactionManager getTransactionManager() {
-                return new JpaTransactionManager(emf);
-            }
-        };
-    }
 
     @Scheduled(fixedRateString = "${spring.batch.document-task-milliseconds}")
     @SchedulerLock(name = "${task.env}")
@@ -132,7 +118,6 @@ public class BatchConfiguration {
     @Bean
     public Step step1() {
         return stepBuilderFactory.get("step1")
-            .transactionManager(transactionManager)
             .<StoredDocument, StoredDocument>chunk(10)
             .reader(undeletedDocumentsWithTtl())
             .processor(deleteExpiredDocumentsProcessor)

--- a/application/src/main/java/uk/gov/hmcts/dm/service/AuditEntryService.java
+++ b/application/src/main/java/uk/gov/hmcts/dm/service/AuditEntryService.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.dm.service;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.dm.domain.*;
 import uk.gov.hmcts.dm.repository.DocumentContentVersionAuditEntryRepository;
 import uk.gov.hmcts.dm.repository.StoredDocumentAuditEntryRepository;
@@ -11,7 +10,6 @@ import java.util.Date;
 import java.util.List;
 
 @Service
-@Transactional
 public class AuditEntryService {
 
     @Autowired

--- a/application/src/main/java/uk/gov/hmcts/dm/service/StoredDocumentService.java
+++ b/application/src/main/java/uk/gov/hmcts/dm/service/StoredDocumentService.java
@@ -4,7 +4,6 @@ import lombok.NonNull;
 import org.hibernate.HibernateException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import uk.gov.hmcts.dm.commandobject.UpdateDocumentCommand;
 import uk.gov.hmcts.dm.commandobject.UploadDocumentsCommand;
@@ -28,7 +27,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-@Transactional
 @Service
 public class StoredDocumentService {
 

--- a/application/src/main/java/uk/gov/hmcts/dm/service/batch/AuditedStoredDocumentBatchOperationsService.java
+++ b/application/src/main/java/uk/gov/hmcts/dm/service/batch/AuditedStoredDocumentBatchOperationsService.java
@@ -4,13 +4,11 @@ import lombok.Getter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.dm.domain.AuditActions;
 import uk.gov.hmcts.dm.domain.StoredDocument;
 import uk.gov.hmcts.dm.service.AuditEntryService;
 import uk.gov.hmcts.dm.service.StoredDocumentService;
 
-@Transactional
 @Service
 public class AuditedStoredDocumentBatchOperationsService {
 


### PR DESCRIPTION
Remove transactional annotations so that spring boot and spring batch don't share a transaction manager.

The codebase appears to have `@Transactional` on classes where it not needed. Sharing transactions between spring boot and sprint batch causes a number of issues so it's simplest to remove the unnecessary transactions. 
