### PR TITLE
Increase TTL test timeout to 20mins

### DIFF
--- a/src/functionalTest/groovy/uk/gov/hmcts/dm/functional/CreateDocumentIT.groovy
+++ b/src/functionalTest/groovy/uk/gov/hmcts/dm/functional/CreateDocumentIT.groovy
@@ -301,7 +301,7 @@ class CreateDocumentIT extends BaseIT {
         def statusCode = null
         def start = LocalDateTime.now()
 
-        while (statusCode != 404 && (Duration.between(start, LocalDateTime.now()).seconds < 600)) {
+        while (statusCode != 404 && (Duration.between(start, LocalDateTime.now()).seconds < 1200)) {
 
             statusCode = givenRequest(CITIZEN)
                 .expect()


### PR DESCRIPTION
### Change description ###
Increases timeout for TTL test as it seems to be taking longer the more full the azure container becomes. Probably needs investigating further when there is time.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
