### PR TITLE
Remove requirements.yaml from chart and add renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,10 @@
+{
+  "helm-requirements": 
+    {
+      "enabled": true,
+      "fileMatch": ["\\Chart.yaml|requirements.yaml$"],
+      "aliases": {
+        "hmctspublic": "https://hmctspublic.azurecr.io/helm/v1/repo/"
+      }
+    }
+}

--- a/charts/dm-store/Chart.yaml
+++ b/charts/dm-store/Chart.yaml
@@ -2,11 +2,15 @@ description: Helm chart for the HMCTS CDM Document Management APO
 apiVersion: v2
 name: dm-store
 home: https://github.com/hmcts/document-management-store-app
-version: 2.1.0
+version: 2.1.1
 maintainers:
   - name: HMCTS Evidence Management Team
     email: EvidenceManagement@HMCTS.NET
 dependencies:
   - name: java
-    version: ~3.0.0
+    version: 3.0.0
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
+  - name: blobstorage
+    version: 0.2.1
+    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
+    condition: blobstorage.enabled

--- a/charts/dm-store/requirements.yaml
+++ b/charts/dm-store/requirements.yaml
@@ -1,8 +1,0 @@
-dependencies:
-  - name: java
-    version: '~2.16.0'
-    repository: '@hmctspublic'
-  - name: blobstorage
-    version: ~0.2.1
-    repository: '@hmctspublic'
-    condition: blobstorage.enabled


### PR DESCRIPTION
From RPE:

> Also, now you can configure Renovate to upgrade helm requirements. It currently doesn't support having ~ in dependancy version ,which is fine as it enables us to upgrade them more rapidly.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
