### PR TITLE
server.use-forward-headers deprecated in springboot 2.2

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -57,7 +57,7 @@ spring:
 
 server:
   port: ${SERVER_PORT:4603}
-  use-forward-headers: false
+  forward-headers-strategy: none
 
 connection:
   upload-timeout-min: ${UPLOAD_TIMEOUT_MIN:60}


### PR DESCRIPTION
### Change description ###
https://github.com/spring-projects/spring-boot/issues/18667


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
