### PR TITLE
Enable Swagger documentation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ There is currently a Java Client available here:
 https://github.com/hmcts/document-management-client
 
 ### Swagger UI
-To view our REST API go to {HOST}:{PORT}/swagger-ui.html
-> http://localhost:8080/swagger-ui.html
+To view our REST API go to {HOST}:{PORT}/swagger-ui/
+> http://localhost:8080/swagger-ui/
 
 ### API Endpoints
 A list of our endpoints can be found here

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ https://github.com/hmcts/document-management-client
 
 ### Swagger UI
 To view our REST API go to {HOST}:{PORT}/swagger-ui/
-> http://localhost:8080/swagger-ui/
+> http://localhost:4603/swagger-ui/
 
 ### API Endpoints
 A list of our endpoints can be found here

--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,8 @@ def versions = [
     gradlePitest       : '1.3.0',
     sonarPitest        : '0.5',
     pact_version       : '4.1.7',
-    emTestHelper       : '1.18.2'
+    emTestHelper       : '1.18.2',
+    springfoxSwagger   : '3.0.0'
 ]
 
 configurations.all {
@@ -290,6 +291,8 @@ dependencies {
     contractTestImplementation('org.junit.jupiter:junit-jupiter-api:5.7.1')
     contractTestCompile sourceSets.main.runtimeClasspath
     contractTestCompile sourceSets.test.runtimeClasspath
+
+    implementation group: 'io.springfox', name: 'springfox-boot-starter', version: versions.springfoxSwagger
 }
 
 dependencyCheck {

--- a/src/main/java/uk/gov/hmcts/dm/config/SwaggerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/dm/config/SwaggerConfiguration.java
@@ -1,0 +1,49 @@
+package uk.gov.hmcts.dm.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.builders.RequestParameterBuilder;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.ParameterType;
+import springfox.documentation.service.RequestParameter;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+import uk.gov.hmcts.dm.controller.StoredDocumentController;
+
+import java.util.Arrays;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfiguration {
+
+    @Bean
+    public Docket apiV2() {
+        return new Docket(DocumentationType.SWAGGER_2)
+            .select()
+            .apis(RequestHandlerSelectors.basePackage(StoredDocumentController.class.getPackage().getName()))
+            .build()
+            .useDefaultResponseMessages(false)
+            .apiInfo(apiV2Info())
+            .globalRequestParameters(Arrays.asList(headerServiceAuthorization()));
+    }
+
+    private ApiInfo apiV2Info() {
+        return new ApiInfoBuilder()
+            .title("Document Management Store App")
+            .description("download, upload")
+            .version("2-beta")
+            .build();
+    }
+
+    private RequestParameter headerServiceAuthorization() {
+        return new RequestParameterBuilder()
+            .name("ServiceAuthorization")
+            .description("Valid Service-to-Service JWT token for a whitelisted micro-service")
+            .in(ParameterType.HEADER)
+            .required(true)
+            .build();
+    }
+}


### PR DESCRIPTION
This enables a swagger endpoint that can be accessed when running the service locally.

It is now available at

http://localhost:4603/swagger-ui/


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
