### PR TITLE
DTSPO-4379 - add --info to functional tests

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -15,7 +15,7 @@ properties([
     ]),
 ])
 
-@Library("Infrastructure")
+@Library("Infrastructure@DTSPO-4379")
 
 def type = "java"
 def product = "dm"


### PR DESCRIPTION
### Change description ###
- Troubleshooting functional tests for the nightly run, setting branch to DTSPO-4379, with --info added to the gradlew command.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
