### PR TITLE
Disable tests that fail on CI which rely on exe upload

### DIFF
--- a/src/functionalTest/groovy/uk/gov/hmcts/dm/functional/AddContentVersionIT.groovy
+++ b/src/functionalTest/groovy/uk/gov/hmcts/dm/functional/AddContentVersionIT.groovy
@@ -171,8 +171,8 @@ class AddContentVersionIT extends BaseIT {
 
     }
 
-    @Ignore
     @Test
+    @Ignore("exe seems to be blocked somewhere causing these tests to fail in CI")
     void "ACV10 As an authenticated user and the owner I should not be able to upload exes"() {
 
         def documentURL = createDocumentAndGetUrlAs CITIZEN

--- a/src/functionalTest/groovy/uk/gov/hmcts/dm/functional/CreateDocumentIT.groovy
+++ b/src/functionalTest/groovy/uk/gov/hmcts/dm/functional/CreateDocumentIT.groovy
@@ -3,10 +3,10 @@ package uk.gov.hmcts.dm.functional
 import io.restassured.response.Response
 import net.thucydides.core.annotations.Pending
 import org.junit.Assert
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.springframework.http.MediaType
-import uk.gov.hmcts.dm.functional.BaseIT
 import uk.gov.hmcts.dm.functional.utilities.Classifications
 import uk.gov.hmcts.dm.functional.utilities.V1MediaTypes
 import uk.gov.hmcts.dm.functional.utilities.V1MimeTypes
@@ -216,6 +216,7 @@ class CreateDocumentIT extends BaseIT {
 
 
     @Test
+    @Ignore("exe seems to be blocked somewhere causing these tests to fail in CI")
     void "CD8 As authenticated user I can not upload files of different format if not on the whitelist (exe)"() {
         givenRequest(CITIZEN)
             .multiPart("files", file(ATTACHMENT_4_PDF), MediaType.APPLICATION_PDF_VALUE)
@@ -424,6 +425,7 @@ class CreateDocumentIT extends BaseIT {
 
 
     @Test
+    @Ignore("exe seems to be blocked somewhere causing these tests to fail in CI")
     void "CD18 As a user I should not be able to upload an exe if its renamed to png"() {
         givenRequest(CITIZEN)
             .multiPart("files", file(EXE_AS_PNG), MediaType.IMAGE_PNG_VALUE)

--- a/src/functionalTest/groovy/uk/gov/hmcts/dm/functional/ErrorPageIT.groovy
+++ b/src/functionalTest/groovy/uk/gov/hmcts/dm/functional/ErrorPageIT.groovy
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.dm.functional
 
 import io.restassured.http.ContentType
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.springframework.http.MediaType
@@ -69,6 +70,7 @@ class ErrorPageIT extends BaseIT {
     }
 
     @Test
+    @Ignore("exe seems to be blocked somewhere causing these tests to fail in CI")
     void "EP5 As an authenticated user trying to post bad attachment, receive JSON error page with 415"() {
 
         givenRequest(CITIZEN)
@@ -198,6 +200,7 @@ class ErrorPageIT extends BaseIT {
     }
 
     @Test
+    @Ignore("exe seems to be blocked somewhere causing these tests to fail in CI")
     void "EP14 As an authenticated user, when I post a EXE document I should get JSON response"() {
 
         givenRequest(CITIZEN)


### PR DESCRIPTION
Somewhere is blocking these files probably at the Palo, which is
probably legitimate we don't want exes being uploaded...
