### PR TITLE
Update log4j to 2.17 to address CVE-2021-45105

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ def versions = [
     shedlock           : '4.29.0',
     springfoxSwagger   : '3.0.0',
     swagger            : '1.6.3',
-    log4JVersion       : '2.16.0'
+    log4JVersion       : '2.17.0'
 ]
 
 dependencyManagement {


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105