### PR TITLE
DO NOT MERGE : Avoid reporting spurious 500 errors in AppInsights

### DIFF
--- a/src/main/java/uk/gov/hmcts/dm/controller/StoredDocumentController.java
+++ b/src/main/java/uk/gov/hmcts/dm/controller/StoredDocumentController.java
@@ -143,7 +143,7 @@ public class StoredDocumentController {
                     response.getOutputStream());
             }
         } catch (UncheckedIOException | IOException e) {
-            logger.info("IOException streaming response", e);
+            logger.warn("IOException streaming response", e);
             if (Objects.nonNull(headers)) {
                 logger.info(String.format("Headers for documentId : %s starts", documentId.toString()));
                 logger.info(String.format("ContentType for documentId : %s is : %s ", documentId.toString(),

--- a/src/main/java/uk/gov/hmcts/dm/controller/StoredDocumentController.java
+++ b/src/main/java/uk/gov/hmcts/dm/controller/StoredDocumentController.java
@@ -116,8 +116,7 @@ public class StoredDocumentController {
     @ApiResponses(value = {
         @ApiResponse(code = 200, message = "Returns contents of a file")
     })
-    public ResponseEntity<Void> getBinary(@PathVariable UUID documentId,
-                                          HttpServletResponse response,
+    public ResponseEntity<Void> getBinary(@PathVariable UUID documentId, HttpServletResponse response,
                                           @RequestHeader Map<String, String> headers,
                                           HttpServletRequest httpServletRequest) {
         var documentContentVersion =
@@ -143,38 +142,30 @@ public class StoredDocumentController {
                     documentContentVersion,
                     response.getOutputStream());
             }
-
         } catch (UncheckedIOException | IOException e) {
             logger.info("IOException streaming response", e);
             if (Objects.nonNull(headers)) {
-                logger.info(
-                    String.format("Headers for documentId : %s starts", documentId.toString()));
-                logger.info(
-                    String.format("ContentType for documentId : %s is : %s ", documentId,
+                logger.info(String.format("Headers for documentId : %s starts", documentId.toString()));
+                logger.info(String.format("ContentType for documentId : %s is : %s ", documentId.toString(),
                         documentContentVersion.getMimeType()));
-                logger.info(
-                    String.format("Size for documentId : %s is : %s ", documentId,
+                logger.info(String.format("Size for documentId : %s is : %s ", documentId.toString(),
                         documentContentVersion.getSize().toString()));
                 headers.forEach((key, value) ->
                     logger.info(String.format("documentId : %s has Request Header %s = %s",
-                        documentId, key, value)));
-                logger.info(
-                    String.format("Headers for documentId : %s ends", documentId));
+                        documentId.toString(), key, value)));
+                logger.info(String.format("Headers for documentId : %s ends", documentId.toString()));
             } else {
-                logger.info(
-                    String.format("Header is null for documentId : %s ", documentId.toString()));
+                logger.info(String.format("Header is null for documentId : %s ", documentId.toString()));
                 if (Objects.nonNull(httpServletRequest)) {
-                    Iterator<String> stringIterator =
-                        httpServletRequest.getHeaderNames().asIterator();
+                    Iterator<String> stringIterator = httpServletRequest.getHeaderNames().asIterator();
                     while (stringIterator.hasNext()) {
                         logger.info(String.format("HeaderNames for documentId : %s  is %s ",
-                            documentId, stringIterator.next()));
+                            documentId.toString(), stringIterator.next()));
                     }
                 }
             }
         }
         return ResponseEntity.ok().build();
     }
-
 }
 


### PR DESCRIPTION
    AppInsights is reporting large numbers of HTTP 500 errors coming from
    this controller, which based on the stacktrace occur when the client
    hangs up the socket.

    The previous code was set to catch these exceptions and return a
    response of HttpStatus.INTERNAL_SERVER_ERROR, however it isn't possible
    to return an HTTP response code at this point - the HTTP code already
    went out when the data was streamed.

    I'm therefore adjusting this method to avoid logging these internal
    errors (which are not internal errors anyhow; IO errors are expected).

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
