### PR TITLE
Resolved batch related tables local setup issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ az acr login --name hmctspublic && az acr login --name hmctsprivate
 docker-compose -f docker-compose-dev.yml pull
 docker-compose -f docker-compose-dev.yml up -d
 
+#Run below script to create the Batch related tables for local set up ONLY
+./bin/create-batch-related-tables-postresql.sh
 
 # Run application
 ./gradlew bootRun

--- a/bin/create-batch-related-tables-postresql.sh
+++ b/bin/create-batch-related-tables-postresql.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+echo "  Creating Batch related tables for local setup ONLY"
+psql -v ON_ERROR_STOP=1 --host=localhost --dbname=evidence --username=evidence <<-EOSQL
+    CREATE TABLE BATCH_JOB_INSTANCE  (
+                                         JOB_INSTANCE_ID BIGINT  NOT NULL PRIMARY KEY ,
+                                         VERSION BIGINT ,
+                                         JOB_NAME VARCHAR(100) NOT NULL,
+                                         JOB_KEY VARCHAR(32) NOT NULL,
+                                         constraint JOB_INST_UN unique (JOB_NAME, JOB_KEY)
+    ) ;
+
+    CREATE TABLE BATCH_JOB_EXECUTION  (
+                                          JOB_EXECUTION_ID BIGINT  NOT NULL PRIMARY KEY ,
+                                          VERSION BIGINT  ,
+                                          JOB_INSTANCE_ID BIGINT NOT NULL,
+                                          CREATE_TIME TIMESTAMP NOT NULL,
+                                          START_TIME TIMESTAMP DEFAULT NULL ,
+                                          END_TIME TIMESTAMP DEFAULT NULL ,
+                                          STATUS VARCHAR(10) ,
+                                          EXIT_CODE VARCHAR(2500) ,
+                                          EXIT_MESSAGE VARCHAR(2500) ,
+                                          LAST_UPDATED TIMESTAMP,
+                                          JOB_CONFIGURATION_LOCATION VARCHAR(2500) NULL,
+                                          constraint JOB_INST_EXEC_FK foreign key (JOB_INSTANCE_ID)
+                                              references BATCH_JOB_INSTANCE(JOB_INSTANCE_ID)
+    ) ;
+
+    CREATE TABLE BATCH_JOB_EXECUTION_PARAMS  (
+                                                 JOB_EXECUTION_ID BIGINT NOT NULL ,
+                                                 TYPE_CD VARCHAR(6) NOT NULL ,
+                                                 KEY_NAME VARCHAR(100) NOT NULL ,
+                                                 STRING_VAL VARCHAR(250) ,
+                                                 DATE_VAL TIMESTAMP DEFAULT NULL ,
+                                                 LONG_VAL BIGINT ,
+                                                 DOUBLE_VAL DOUBLE PRECISION ,
+                                                 IDENTIFYING CHAR(1) NOT NULL ,
+                                                 constraint JOB_EXEC_PARAMS_FK foreign key (JOB_EXECUTION_ID)
+                                                     references BATCH_JOB_EXECUTION(JOB_EXECUTION_ID)
+    ) ;
+
+    CREATE TABLE BATCH_STEP_EXECUTION  (
+                                           STEP_EXECUTION_ID BIGINT  NOT NULL PRIMARY KEY ,
+                                           VERSION BIGINT NOT NULL,
+                                           STEP_NAME VARCHAR(100) NOT NULL,
+                                           JOB_EXECUTION_ID BIGINT NOT NULL,
+                                           START_TIME TIMESTAMP NOT NULL ,
+                                           END_TIME TIMESTAMP DEFAULT NULL ,
+                                           STATUS VARCHAR(10) ,
+                                           COMMIT_COUNT BIGINT ,
+                                           READ_COUNT BIGINT ,
+                                           FILTER_COUNT BIGINT ,
+                                           WRITE_COUNT BIGINT ,
+                                           READ_SKIP_COUNT BIGINT ,
+                                           WRITE_SKIP_COUNT BIGINT ,
+                                           PROCESS_SKIP_COUNT BIGINT ,
+                                           ROLLBACK_COUNT BIGINT ,
+                                           EXIT_CODE VARCHAR(2500) ,
+                                           EXIT_MESSAGE VARCHAR(2500) ,
+                                           LAST_UPDATED TIMESTAMP,
+                                           constraint JOB_EXEC_STEP_FK foreign key (JOB_EXECUTION_ID)
+                                               references BATCH_JOB_EXECUTION(JOB_EXECUTION_ID)
+    ) ;
+
+    CREATE TABLE BATCH_STEP_EXECUTION_CONTEXT  (
+                                                   STEP_EXECUTION_ID BIGINT NOT NULL PRIMARY KEY,
+                                                   SHORT_CONTEXT VARCHAR(2500) NOT NULL,
+                                                   SERIALIZED_CONTEXT TEXT ,
+                                                   constraint STEP_EXEC_CTX_FK foreign key (STEP_EXECUTION_ID)
+                                                       references BATCH_STEP_EXECUTION(STEP_EXECUTION_ID)
+    ) ;
+
+    CREATE TABLE BATCH_JOB_EXECUTION_CONTEXT  (
+                                                  JOB_EXECUTION_ID BIGINT NOT NULL PRIMARY KEY,
+                                                  SHORT_CONTEXT VARCHAR(2500) NOT NULL,
+                                                  SERIALIZED_CONTEXT TEXT ,
+                                                  constraint JOB_EXEC_CTX_FK foreign key (JOB_EXECUTION_ID)
+                                                      references BATCH_JOB_EXECUTION(JOB_EXECUTION_ID)
+    ) ;
+
+    CREATE SEQUENCE BATCH_STEP_EXECUTION_SEQ MAXVALUE 9223372036854775807 NO CYCLE;
+    CREATE SEQUENCE BATCH_JOB_EXECUTION_SEQ MAXVALUE 9223372036854775807 NO CYCLE;
+    CREATE SEQUENCE BATCH_JOB_SEQ MAXVALUE 9223372036854775807 NO CYCLE;
+EOSQL


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A
### Change description ###
Resolved batch related tables local setup issue. Currently batch related tables are not created on Docker startup locally. So when we bootrun the Application. Application fails to start complaining about missing batch table.
**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```
