### PR TITLE
Add forwardedheaderfilter to work with traefik v2 proxy

### DIFF
--- a/src/main/java/uk/gov/hmcts/dm/config/WebConfig.java
+++ b/src/main/java/uk/gov/hmcts/dm/config/WebConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.hateoas.config.EnableHypermediaSupport;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.web.filter.ForwardedHeaderFilter;
 import org.springframework.web.servlet.LocaleResolver;
 import org.springframework.web.servlet.i18n.FixedLocaleResolver;
 
@@ -38,6 +39,11 @@ public class WebConfig {
                 protocolHandler.setConnectionUploadTimeout(1000 * 60 * connectionUploadTimeoutMinutes);
             }
         });
+    }
+
+    @Bean
+    ForwardedHeaderFilter forwardedHeaderFilter() {
+        return new ForwardedHeaderFilter();
     }
 
 }


### PR DESCRIPTION
- Currently, tests (probably clients too) rely on HATEOAS links being sent from response of create document to do a get of the document. 
- Though we are invoking tests with https, HATEOAS is creating the rel links as http. Test fail  with 404 when doing a GET on the document with this `http` rel link  as traefik v2 doesn't support both http and https like traefik v1 . 
- As ssl is terminated at traefik , actual application is getting a http call. Spring is ignoring the `x-forwarded-proto` it is being sent . Adding the filter will let spring honour these headers and resolve to https urls in rel links. https://docs.spring.io/spring-hateoas/docs/current/reference/html/#server.link-builder.forwarded-headers

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
