### PR TITLE
Ensure document version itm_idx is updated

### DIFF
--- a/src/main/java/uk/gov/hmcts/dm/service/StoredDocumentService.java
+++ b/src/main/java/uk/gov/hmcts/dm/service/StoredDocumentService.java
@@ -142,6 +142,7 @@ public class StoredDocumentService {
                                                                                    securityUtilService.getUserId());
         storedDocument.getDocumentContentVersions().add(documentContentVersion);
         documentContentVersionRepository.save(documentContentVersion);
+        storedDocumentRepository.save(storedDocument);
         storeInAzureBlobStorage(storedDocument, documentContentVersion, file);
 
         return documentContentVersion;


### PR DESCRIPTION
If we disable spring's open-in-view there will be no Hibernate session associated with the StoredDocument object that will automatically persist any modifications we make to it.

We now need to explicitly save the StoredDocument when we add the new version to its list of document versions, which will cause itm_idx to be set for the new version.

