### PR TITLE
Only create container if it does not exist

### DIFF
--- a/src/main/java/uk/gov/hmcts/dm/config/azure/AzureStorageConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/dm/config/azure/AzureStorageConfiguration.java
@@ -40,12 +40,10 @@ public class AzureStorageConfiguration {
             .containerName(containerReference)
             .buildClient();
 
-        try {
+        if (!client.exists()) {
             client.createIfNotExists();
-            return client;
-        } catch (BlobStorageException e) {
-            return client;
         }
+        return client;
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/dm/config/azure/AzureStorageConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/dm/config/azure/AzureStorageConfiguration.java
@@ -40,10 +40,12 @@ public class AzureStorageConfiguration {
             .containerName(containerReference)
             .buildClient();
 
-        if (!client.exists()) {
+        try {
             client.createIfNotExists();
+            return client;
+        } catch (BlobStorageException e) {
+            return client;
         }
-        return client;
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/dm/config/azure/AzureStorageConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/dm/config/azure/AzureStorageConfiguration.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.dm.config.azure;
 
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobContainerClientBuilder;
-import com.azure.storage.blob.models.BlobStorageException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/uk/gov/hmcts/dm/config/azure/AzureStorageConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/dm/config/azure/AzureStorageConfiguration.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.dm.config.azure;
 
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobContainerClientBuilder;
+import com.azure.storage.blob.models.BlobStorageException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/uk/gov/hmcts/dm/config/azure/AzureStorageConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/dm/config/azure/AzureStorageConfiguration.java
@@ -41,7 +41,7 @@ public class AzureStorageConfiguration {
             .buildClient();
 
         try {
-            client.createIfNotExists();
+            client.create();
             return client;
         } catch (BlobStorageException e) {
             return client;

--- a/src/main/java/uk/gov/hmcts/dm/config/azure/AzureStorageConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/dm/config/azure/AzureStorageConfiguration.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.dm.config.azure;
 
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobContainerClientBuilder;
-import com.azure.storage.blob.models.BlobStorageException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -43,7 +42,7 @@ public class AzureStorageConfiguration {
         try {
             client.create();
             return client;
-        } catch (BlobStorageException e) {
+        } catch (Exception e) {
             return client;
         }
     }

--- a/src/main/java/uk/gov/hmcts/dm/config/azure/MetaDataAzureStorageConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/dm/config/azure/MetaDataAzureStorageConfiguration.java
@@ -44,7 +44,7 @@ public class MetaDataAzureStorageConfiguration {
         try {
             client.create();
             return client;
-        } catch (BlobStorageException e) {
+        } catch (Exception e) {
             return client;
         }
     }

--- a/src/main/java/uk/gov/hmcts/dm/config/azure/MetaDataAzureStorageConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/dm/config/azure/MetaDataAzureStorageConfiguration.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.dm.config.azure;
 
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobContainerClientBuilder;
-import com.azure.storage.blob.models.BlobStorageException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/uk/gov/hmcts/dm/config/azure/MetaDataAzureStorageConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/dm/config/azure/MetaDataAzureStorageConfiguration.java
@@ -41,10 +41,12 @@ public class MetaDataAzureStorageConfiguration {
 
         final BlobContainerClient client = getClient(blobAddress, metadataContainerName);
 
-        if (!client.exists()) {
+        try {
             client.createIfNotExists();
+            return client;
+        } catch (BlobStorageException e) {
+            return client;
         }
-        return client;
     }
 
     BlobContainerClient getClient(String blobAddress, String containerName) {
@@ -66,10 +68,12 @@ public class MetaDataAzureStorageConfiguration {
 
         final BlobContainerClient client = getClient(blobAddress, orphanDocumentContainerName);
 
-        if (!client.exists()) {
+        try {
             client.createIfNotExists();
+            return client;
+        } catch (BlobStorageException e) {
+            return client;
         }
-        return client;
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/dm/config/azure/MetaDataAzureStorageConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/dm/config/azure/MetaDataAzureStorageConfiguration.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.dm.config.azure;
 
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobContainerClientBuilder;
+import com.azure.storage.blob.models.BlobStorageException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/uk/gov/hmcts/dm/config/azure/MetaDataAzureStorageConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/dm/config/azure/MetaDataAzureStorageConfiguration.java
@@ -42,7 +42,7 @@ public class MetaDataAzureStorageConfiguration {
         final BlobContainerClient client = getClient(blobAddress, metadataContainerName);
 
         try {
-            client.createIfNotExists();
+            client.create();
             return client;
         } catch (BlobStorageException e) {
             return client;
@@ -69,7 +69,7 @@ public class MetaDataAzureStorageConfiguration {
         final BlobContainerClient client = getClient(blobAddress, orphanDocumentContainerName);
 
         try {
-            client.createIfNotExists();
+            client.create();
             return client;
         } catch (BlobStorageException e) {
             return client;

--- a/src/main/java/uk/gov/hmcts/dm/config/azure/MetaDataAzureStorageConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/dm/config/azure/MetaDataAzureStorageConfiguration.java
@@ -41,12 +41,10 @@ public class MetaDataAzureStorageConfiguration {
 
         final BlobContainerClient client = getClient(blobAddress, metadataContainerName);
 
-        try {
+        if (!client.exists()) {
             client.createIfNotExists();
-            return client;
-        } catch (BlobStorageException e) {
-            return client;
         }
+        return client;
     }
 
     BlobContainerClient getClient(String blobAddress, String containerName) {
@@ -68,12 +66,10 @@ public class MetaDataAzureStorageConfiguration {
 
         final BlobContainerClient client = getClient(blobAddress, orphanDocumentContainerName);
 
-        try {
+        if (!client.exists()) {
             client.createIfNotExists();
-            return client;
-        } catch (BlobStorageException e) {
-            return client;
         }
+        return client;
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/dm/config/azure/MetaDataAzureStorageConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/dm/config/azure/MetaDataAzureStorageConfiguration.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.dm.config.azure;
 
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobContainerClientBuilder;
-import com.azure.storage.blob.models.BlobStorageException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -71,7 +70,7 @@ public class MetaDataAzureStorageConfiguration {
         try {
             client.create();
             return client;
-        } catch (BlobStorageException e) {
+        } catch (Exception e) {
             return client;
         }
     }


### PR DESCRIPTION
### Change description ###

Fixes an issue with azurite via docker where the dm-store crashes if the container already exists. The original try catch was there to stop this but it appears that the exception type has changed over time. This is a better solution based off https://github.com/Azure/azure-functions-host/pull/9555/files

