### PR TITLE
add graceful shutdown

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -63,6 +63,7 @@ spring:
 server:
   port: ${SERVER_PORT:4603}
   forward-headers-strategy: none
+  shutdown: graceful
 
 connection:
   upload-timeout-min: ${UPLOAD_TIMEOUT_MIN:60}


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/EM-5788


### Change description ###
add graceful shutdown using default value of 30s for spring timeout and kubernetes grace period
