### PR TITLE
EM-6263: fix document could not be parsed

### DIFF
--- a/src/main/java/uk/gov/hmcts/dm/service/PasswordVerifier.java
+++ b/src/main/java/uk/gov/hmcts/dm/service/PasswordVerifier.java
@@ -39,9 +39,9 @@ public class PasswordVerifier {
             } catch (TikaException e) {
                 logger.error("Document with Name : {} is password protected", multipartFile.getOriginalFilename());
                 return false;
-            } catch (IOException | SAXException e) {
+62            } catch (IOException | SAXException e) {
                 logger.error("Document with Name : {} could not be parsed", multipartFile.getOriginalFilename());
-                return false;
+                return true;
             }
         }
         return true;


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/EM-6263

### Change description
Changing parser behavior to return true on IO/SAX exceptions due to the parser only being used to check for password protedction.

### Testing done

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
