### PR TITLE
EM-6379 remove DirtiesContext ro speed up pitests

### DIFF
--- a/src/test/java/uk/gov/hmcts/dm/componenttests/ComponentTestBase.java
+++ b/src/test/java/uk/gov/hmcts/dm/componenttests/ComponentTestBase.java
@@ -43,7 +43,6 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 @SpringBootTest(webEnvironment = MOCK)
 @Transactional
 @EnableSpringDataWebSupport
-@DirtiesContext
 public abstract class ComponentTestBase {
 
 

--- a/src/test/java/uk/gov/hmcts/dm/componenttests/ComponentTestBase.java
+++ b/src/test/java/uk/gov/hmcts/dm/componenttests/ComponentTestBase.java
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;


### PR DESCRIPTION
### Jira link
[EM-6379](https://tools.hmcts.net/jira/browse/EM-6379) remove DirtiesContext to speed up pitests
removing "DirtiesContext' to stop recreating spring context for each test.

it reduced time to 27 min.
<img width="1221" alt="Screenshot 2025-01-13 at 14 23 11" src="https://github.com/user-attachments/assets/5df422c3-5189-4d9b-a90b-59c98a972bf4" />

