### PR TITLE
limit parsing for PasswordVerifier

### DIFF
--- a/src/main/java/uk/gov/hmcts/dm/service/PasswordVerifier.java
+++ b/src/main/java/uk/gov/hmcts/dm/service/PasswordVerifier.java
@@ -22,8 +22,8 @@ public class PasswordVerifier {
     public boolean checkPasswordProtectedFile(MultipartFile multipartFile) {
         if (!multipartFile.isEmpty()) {
             try {
-                new AutoDetectParser().parse(multipartFile.getInputStream(), new BodyContentHandler(),
-                    new Metadata(), new ParseContext());
+                new AutoDetectParser().parse(multipartFile.getInputStream(),
+                    new BodyContentHandler(1024 * 1024), new Metadata(), new ParseContext());
 
             } catch (TikaException e) {
                 logger.error("Document with Name : {} is password protected", multipartFile.getOriginalFilename());


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/EM-6725

### Change description
limit parsing for PasswordVerifier to 1MB as a size limit to restrict how much content is processed or stored in memory and reduce the time taken for this verification with large documents.